### PR TITLE
Increase timeout.

### DIFF
--- a/rust/actyx/swarm/harness/src/bin/health.rs
+++ b/rust/actyx/swarm/harness/src/bin/health.rs
@@ -291,7 +291,7 @@ fn main() {
                     }
                     None
                 });
-                match timeout(Duration::from_secs(60), fut).await {
+                match timeout(Duration::from_secs(80), fut).await {
                     Ok(Some(true)) => {}
                     Ok(_) => panic!(),
                     Err(_) => {


### PR DESCRIPTION
This looks like a timeout to me (the node connected and the timer expired at the same time).

```
Aug 10 17:25:40.625  INFO health: Machine-#1 is 12D3KooWMm1c4pzeLPGkkCJMAgFbsfQ8xmVDusg272icWsaNHWzN
Aug 10 17:27:40.672  INFO health: waiting for Machine-#4 to connect to Machine-#1
Aug 10 17:27:40.672  INFO health: Machine-#4 connected to 12D3KooWMm1c4pzeLPGkkCJMAgFbsfQ8xmVDusg272icWsaNHWzN
Aug 10 17:27:40.672 ERROR panic: thread 'main' panicked at 'timeout': swarm/harness/src/bin/health.rs:318  
```