### PR TITLE
rust/: Add `rust-toolchain.toml` file

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.54.0"
+profile = "default"


### PR DESCRIPTION
This serves as a directory override for all sub directories, instructing
`rustup` to use the specified toolchain.
The toolchain will also be automagically downloaded if not present.

I think this will save some headaches down the road.