### PR TITLE
Revert open source change in JS libs for now

### DIFF
--- a/js/pond/README.md
+++ b/js/pond/README.md
@@ -59,7 +59,3 @@ import { Pond, Tag, Fish, FishId } from '@actyx/pond'
 
 ## Recommended VSCode plugins
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for live source code linting
-
-## Contributing
-
-PRs are very welcome. Please review the contribution notes in [the root README](https://github.com/Actyx/Actyx/blob/master/README.md#contributing).

--- a/js/pond/package.json
+++ b/js/pond/package.json
@@ -57,7 +57,7 @@
     "datastore",
     "offline-first"
   ],
-  "license": "Apache-2.0",
+  "license": "GPL-2.0-only",
   "main": "./lib/index.js",
   "name": "@actyx/pond",
   "repository": {

--- a/js/sdk/README.md
+++ b/js/sdk/README.md
@@ -50,7 +50,3 @@ import { Actyx, Tags } from '@actyx/sdk'
     })
 })()
 ```
-
-## Contributing
-
-PRs are very welcome. Please review the contribution notes in [the root README](https://github.com/Actyx/Actyx/blob/master/README.md#contributing).

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -68,7 +68,7 @@
     "datastore",
     "offline-first"
   ],
-  "license": "Apache-2.0",
+  "license": "GPL-2.0-only",
   "main": "./lib/index.js",
   "name": "@actyx/sdk",
   "repository": {


### PR DESCRIPTION
Remove indicators of full open source for the time being, so that we can continue releasing these packages while the open source plan is still being finalized.