### PR TITLE
Update ipfs-embed

### DIFF
--- a/rust/actyx/Cargo.lock
+++ b/rust/actyx/Cargo.lock
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "ipfs-embed"
 version = "0.22.4"
-source = "git+https://github.com/wngr/ipfs-embed?branch=sim-open#72ae09bdc9d23136a44190ba99e1818b1f3d2bcd"
+source = "git+https://github.com/Actyx/ipfs-embed?branch=sim-open#7035d30ef69e31051ac7c25fa9868aabbbda54bd"
 dependencies = [
  "anyhow",
  "async-io",

--- a/rust/actyx/Cargo.toml
+++ b/rust/actyx/Cargo.toml
@@ -33,7 +33,7 @@ panic = "abort"
 
 [patch.crates-io]
 # wait for ipfs-embed 0.23
-ipfs-embed = { git = "https://github.com/wngr/ipfs-embed", branch = "sim-open" }
+ipfs-embed = { git = "https://github.com/Actyx/ipfs-embed", branch = "sim-open" }
 libp2p = { git = "https://github.com/Actyx/rust-libp2p", branch = "sim-open" }
 libp2p-bitswap = { git = "https://github.com/Actyx/libp2p-bitswap", branch = "sim-open" }
 libp2p-broadcast = { git = "https://github.com/Actyx/libp2p-broadcast", branch = "sim-open-2" }


### PR DESCRIPTION
As the gc task wasn't prematurely killed anymore (#228), the task now
blocked the tokio runtime from shutting down.

~Waiting for https://github.com/ipfs-rust/ipfs-embed/pull/105~