### PR TITLE
rust/release: limit parallelism to 6

### DIFF
--- a/rust/release/src/main.rs
+++ b/rust/release/src/main.rs
@@ -341,6 +341,9 @@ Overview:"#
                 } else {
                     let tmp = tempdir()?;
                     log::debug!("Temp dir for {}: {}", release, tmp.path().display());
+
+                    // CI has too many cores
+                    rayon::ThreadPoolBuilder::new().num_threads(6).build_global().unwrap();
                     let out = OsArch::all()
                         .par_iter()
                         .map(|os_arch| {


### PR DESCRIPTION
The CI servers have 64 cores, thus the default rayon thread pools
contains 64 threads. This is apparently too much for the poor azure API.