### PR TITLE
Check target before source in release process

### DIFF
--- a/rust/release/src/main.rs
+++ b/rust/release/src/main.rs
@@ -354,11 +354,11 @@ Overview:"#
                                     .map(|mut p| {
                                         let mut out = String::new();
                                         let source_exists = p.source_exists()?;
-                                        if source_exists {
-                                            let target_exists = p.target_exists()?;
-                                            if target_exists {
-                                                writeln!(&mut out, "    [OK] {} already exists.", p.target)?;
-                                            } else {
+                                        let target_exists = p.target_exists()?;
+                                        if target_exists {
+                                            writeln!(&mut out, "    [OK] {} already exists.", p.target)?;
+                                        } else {
+                                            if source_exists {
                                                 log::debug!(
                                                     "creating release artifact in dir {}",
                                                     tmp.path().display()
@@ -379,12 +379,16 @@ Overview:"#
                                                     log::debug!("finished publishing");
                                                     writeln!(&mut out, "    [NEW] {}", p.target)?;
                                                 }
+                                            } else {
+                                                if !ignore_errors && !dry_run {
+                                                    anyhow::bail!("    [ERR] Source \"{}\" does NOT exist.", p.source);
+                                                }
+                                                writeln!(
+                                                    &mut out,
+                                                    "    [ERR] Source \"{}\" does NOT exist.",
+                                                    p.source
+                                                )?;
                                             }
-                                        } else {
-                                            if !ignore_errors && !dry_run {
-                                                anyhow::bail!("    [ERR] Source \"{}\" does NOT exist.", p.source);
-                                            }
-                                            writeln!(&mut out, "    [ERR] Source \"{}\" does NOT exist.", p.source)?;
                                         }
                                         Ok(out)
                                     })


### PR DESCRIPTION
I deleted a lot of artifacts from our Azure Blob Store account intending to keep only those artifacts we released. Unfortunately, I used the versions file in Actyx/Cosmos instead of Actyx/Actyx and as such screwed all this up. This is the simplest fix of the issue.

Note that there was no logical reason to check the source first since we don't check source against target or anything as such.