### PR TITLE
Actyx Release

### DIFF
--- a/versions
+++ b/versions
@@ -3,6 +3,7 @@
 # The machine-readable product names are: actyx, node-manager,
 # cli, pond, ts-sdk, rust-sdk, docs, csharp-sdk
 
+actyx-2.9.2 ae451aec9f1d31027846f621c73628f78ca2d31d
 actyx-2.9.1 76a15a0a6fa2d4952911c400b70580993533627c
 actyx-2.9.0 e028897e9cd42d0d7e0b9c8696b49d29438db016
 actyx-2.8.2 bd20d6555c768a1d1fd4f15ae1995d02dab2b2c3


### PR DESCRIPTION
-------------------------
Overview:
  * actyx:		2.9.1 --> 2.9.2
-------------------------
Detailed changelog:
* actyx		2.9.2
    * Bug fix: increase bitswap MAX_BLOCK_SIZE to 2MB to prevent synchronisation errors [ae451aec9f1d31027846f621c73628f78ca2d31d]
-------------------------
Commit of release: ae451aec9f1d31027846f621c73628f78ca2d31d
Time of release: 2021-12-15 14:17:25 UTC