### PR TITLE
Actyx Release

### DIFF
--- a/versions
+++ b/versions
@@ -3,6 +3,7 @@
 # The machine-readable product names are: actyx, node-manager,
 # cli, pond, ts-sdk, rust-sdk, docs, csharp-sdk
 
+actyx-2.16.0 93947ecdc70b5e4b503d13518650c6fdb7b53cbc
 actyx-2.15.0 7119b21dad7b92922e03a205fa0ed07a8bdadefc
 actyx-2.14.1 06fac6dfc9258047cb39a74636178218f4609a85
 actyx-2.14.0 d46f6564c389ce1a2d622fcd5bfd81c83535f191
@@ -36,6 +37,7 @@ actyx-2.0.2 bad26dbcbee2a7133204000bdf750b6a42e081af
 actyx-2.0.1 429ce866c56b2e065495bebc8253b22c378a1954
 actyx-2.0.0 894ccba22f97fb037b4a63b99462dff30d26f37a
 actyx-1.1.5 1980025440797cec2e286177083f03eb9c44511b
+cli-3.2.0 93947ecdc70b5e4b503d13518650c6fdb7b53cbc
 cli-3.1.0 d46f6564c389ce1a2d622fcd5bfd81c83535f191
 cli-3.0.0 18e340a959b01de8a1e5bdc19556dfd84712a4df
 cli-2.6.0 d946b32cdace404500172c32a76eec628ee1870c


### PR DESCRIPTION
-------------------------
Overview:
  * actyx:		2.15.0 --> 2.16.0
  * cli:		3.1.0 --> 3.2.0
-------------------------
Detailed changelog:
* actyx		2.16.0
    * New feature: add `appId(me)` as an alias for the requesting app’s ID [190011e8182be05395bd4e607c4a96f37273f764]
    * New feature: extend the admin protocol to support deletion of non-active topic data [5e800dd90b3effb5b3bb6c73933504e5312c719c]
    * New feature: extend the admin protocol to support listing known topics [5e800dd90b3effb5b3bb6c73933504e5312c719c]
    * New feature: remove the v1 to v2 migration code [807198208ac289223bfbf1807a715127786bfd8a]
    * New feature: implement support for event retention policies [bca790c10023810eba05d5dc94ca3355c6541ca9]
* cli		3.2.0
    * New feature: allow deleting non-active topic data [5e800dd90b3effb5b3bb6c73933504e5312c719c]
    * New feature: allow listing known topics [5e800dd90b3effb5b3bb6c73933504e5312c719c]
-------------------------
Commit of release: 93947ecdc70b5e4b503d13518650c6fdb7b53cbc
Time of release: 2023-07-13 12:45:01 UTC
