### PR TITLE
Actyx Release

### DIFF
--- a/versions
+++ b/versions
@@ -3,6 +3,7 @@
 # The machine-readable product names are: actyx, node-manager,
 # cli, pond, ts-sdk, rust-sdk, docs, csharp-sdk
 
+actyx-2.16.1 b813c08faa67cd50eab00f5568a63c71bd2208fa
 actyx-2.16.0 40fbd9adb978c36fcb5d77b062088e3f72af7f69
 actyx-2.15.0 7119b21dad7b92922e03a205fa0ed07a8bdadefc
 actyx-2.14.1 06fac6dfc9258047cb39a74636178218f4609a85


### PR DESCRIPTION
-------------------------
Overview:
  * actyx:		2.16.0 --> 2.16.1
-------------------------
Detailed changelog:
* actyx		2.16.1
    * Bug fix: batch adding peer/address pairs to avoid overloading the store channel [725a765cae0e2d3f34723a043f9b03839acfcdcd]
-------------------------
Commit of release: b813c08faa67cd50eab00f5568a63c71bd2208fa
Time of release: 2023-07-24 10:04:58 UTC
