### PR TITLE
Actyx Release

### DIFF
--- a/versions
+++ b/versions
@@ -3,6 +3,7 @@
 # The machine-readable product names are: actyx, node-manager,
 # cli, pond, ts-sdk, rust-sdk, docs, csharp-sdk
 
+actyx-2.16.1 c631e69b6b045ece404a41397b835879396dc863
 actyx-2.16.0 40fbd9adb978c36fcb5d77b062088e3f72af7f69
 actyx-2.15.0 7119b21dad7b92922e03a205fa0ed07a8bdadefc
 actyx-2.14.1 06fac6dfc9258047cb39a74636178218f4609a85
@@ -50,6 +51,7 @@ cli-2.1.0 70c6be97ed8cabc5abc004c5af63fc33051f2c34
 cli-2.0.1 ad16d49946809a8b07339ff4127f3d981606af45
 cli-2.0.0 894ccba22f97fb037b4a63b99462dff30d26f37a
 cli-1.1.5 1980025440797cec2e286177083f03eb9c44511b
+node-manager-2.11.0 c631e69b6b045ece404a41397b835879396dc863
 node-manager-2.10.0 4b55c0053b3cf9ee9bf7f2f03ee309cb9effd215
 node-manager-2.9.3 4756b7eaef218edcb3f00781cde403dbbb6a9a25
 node-manager-2.9.2 4abef32c3082d9af45bb801b5b86ec0c75709675


### PR DESCRIPTION
-------------------------
Overview:
  * actyx:		2.16.0 --> 2.16.1
  * node-manager:		2.10.0 --> 2.11.0
-------------------------
Detailed changelog:
* actyx		2.16.1
    * Bug fix: batch adding peer/address pairs to avoid overloading the store channel [725a765cae0e2d3f34723a043f9b03839acfcdcd]
* node-manager		2.11.0
    * New feature: add support for topic management [855c3eaef5bb0dd4331c2f91be1f292124e661fc]
-------------------------
Commit of release: c631e69b6b045ece404a41397b835879396dc863
Time of release: 2023-07-24 11:20:48 UTC
