### PR TITLE
Actyx Release

### DIFF
--- a/versions
+++ b/versions
@@ -3,6 +3,7 @@
 # The machine-readable product names are: actyx, node-manager,
 # cli, pond, ts-sdk, rust-sdk, docs, csharp-sdk
 
+actyx-2.16.2 990707480af94af65985fbfaa372d2fa4ecfdd1f
 actyx-2.16.1 d12ab8362fcb4a21808d40c27b0c495c41412787
 actyx-2.16.0 40fbd9adb978c36fcb5d77b062088e3f72af7f69
 actyx-2.15.0 7119b21dad7b92922e03a205fa0ed07a8bdadefc


### PR DESCRIPTION
-------------------------
Overview:
  * actyx:		2.16.1 --> 2.16.2
-------------------------
Detailed changelog:
* actyx		2.16.2
    * Bug fix: sign android apks [dbf4a12bd9281a32854534f4340a28664e03c15a]
-------------------------
Commit of release: 990707480af94af65985fbfaa372d2fa4ecfdd1f
Time of release: 2023-09-04 15:31:02 UTC
