### PR TITLE
make pond depend on sdk 0.5.7

### DIFF
--- a/integration/package-lock.json
+++ b/integration/package-lock.json
@@ -47,13 +47,13 @@
     },
     "../js/pond": {
       "name": "@actyx/pond",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "bundleDependencies": [
         "rxjs"
       ],
       "license": "GPL-2.0-only",
       "dependencies": {
-        "@actyx/sdk": "0.5.7",
+        "@actyx/sdk": "^0.5.7",
         "fp-ts": "2.11.5",
         "immutable": "4.0.0",
         "io-ts": "2.2.16",
@@ -20017,7 +20017,7 @@
     "@actyx/pond": {
       "version": "file:../js/pond",
       "requires": {
-        "@actyx/sdk": "0.5.7",
+        "@actyx/sdk": "^0.5.7",
         "@microsoft/api-extractor": "^7.19.2",
         "@types/jest": "27.0.3",
         "@types/ramda": "0.27.60",

--- a/js/pond/package-lock.json
+++ b/js/pond/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@actyx/pond",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@actyx/pond",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "bundleDependencies": [
         "rxjs"
       ],
       "license": "GPL-2.0-only",
       "dependencies": {
-        "@actyx/sdk": "0.5.7",
+        "@actyx/sdk": "^0.5.7",
         "fp-ts": "2.11.5",
         "immutable": "4.0.0",
         "io-ts": "2.2.16",

--- a/js/pond/package.json
+++ b/js/pond/package.json
@@ -4,7 +4,7 @@
     "url": "https://groups.google.com/a/actyx.io/g/developers/"
   },
   "dependencies": {
-    "@actyx/sdk": "0.5.7",
+    "@actyx/sdk": "^0.5.7",
     "fp-ts": "2.11.5",
     "immutable": "4.0.0",
     "io-ts": "2.2.16",
@@ -83,5 +83,5 @@
     "build:docs": "rm -rf ../../web/developer.actyx.com/static/@actyx/pond/ && typedoc --mode library --options typedoc.json src/index.ts"
   },
   "types": "./lib/index.d.ts",
-  "version": "3.4.0"
+  "version": "3.4.1"
 }


### PR DESCRIPTION
The published 3.4.0 depends strictly on SDK 0.5.6, which is deprecated due to some publishing issue.
