### PR TITLE
Add --expires-in to ax-certs

### DIFF
--- a/rust/actyx/Cargo.lock
+++ b/rust/actyx/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "chrono",
  "crypto",
  "derive_more",
+ "lazy_static",
  "regex",
  "serde",
  "serde_cbor",

--- a/rust/actyx/certs/Cargo.toml
+++ b/rust/actyx/certs/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.52"
 base64 = "0.13.0"
 chrono = "0.4.19"
 derive_more = "0.99.17"
+lazy_static = "1.4.0"
 regex = "1.5.4"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_cbor = "0.11.2"

--- a/rust/actyx/certs/src/bin/ax-cert.rs
+++ b/rust/actyx/certs/src/bin/ax-cert.rs
@@ -36,6 +36,17 @@ struct AppLicenseOpts {
     #[structopt(long)]
     expires_at: Option<DateTime<Utc>>,
 
+    /// The amount of time in which the license should expire. The accepted format is
+    /// composed of a number followed by a unit (i.e. "10Y"), whitespace is supported
+    /// before, between and after the number and the unit. Values are accepted in
+    /// descending order according to the size of the unit, the unit character and
+    /// ordering is as follows:
+    ///
+    /// [Y]ear, [M]onth, [w]eek, [d]ay, [h]our, [d]ay, [m]inute, [s]econd
+    ///
+    /// Note: Years are considered to be 365 days long and months to be 30 days long.
+    ///
+    /// For example: "1Y 3M 4h" means that the license should expire in 1 year, 3 months and 4 hours.
     #[structopt(long, parse(try_from_str = parse_expires_in))]
     expires_in: Option<DateTime<Utc>>,
 


### PR DESCRIPTION
closes #512 

I'm showing both commits so you can pick between them, I didn't benchmark it but this is for a "single-use command" so I'm more interested in what you think is more readable

18f5d6120795ea801b29bf1f85072d34440bac2b uses a regex for parsing 
d26525e8e2a394d493e725c7cadca23e25f37690 uses _Just Code TM_ for parsing (this commit is actually buggy but after fixing the errors it passes the tests as well)
