### PR TITLE
Rollback the publishing method

### DIFF
--- a/docker/actyx/Dockerfile
+++ b/docker/actyx/Dockerfile
@@ -63,9 +63,9 @@ EXPOSE 4001/TCP
 
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.title="Actyx" \
-    org.opencontainers.image.description="Some description for Actyx" \
+    org.opencontainers.image.description="Local-First Cooperation based on Event Sourcing" \
     org.opencontainers.image.vendor="Actyx AG" \
     org.opencontainers.image.revision="${GIT_COMMIT}" \
     org.opencontainers.image.created="TODO" \
-    org.opencontainers.image.version="TODO" \
-    org.opencontainers.image.documentation="https://developer.actyx.com" \
+    org.opencontainers.image.version="${ACTYX_VERSION}" \
+    org.opencontainers.image.documentation="https://developer.actyx.com"

--- a/rust/release/src/main.rs
+++ b/rust/release/src/main.rs
@@ -353,7 +353,6 @@ Overview:"#
         } => {
             let head_of_origin_master = repo.head_of_origin_master()?;
             let head = repo.head_hash()?;
-            let repo_workdir = repo.workdir()?;
             anyhow::ensure!(
                 dry_run || (head_of_origin_master == head) || force,
                 "Not up to date with origin/master \
@@ -394,14 +393,15 @@ Overview:"#
                                         } else if source_exists {
                                             needed_write.store(true, Ordering::Relaxed);
                                             log::debug!("creating release artifact in dir {}", tmp.path().display());
-                                            p.create_release_artifact(tmp.path(), repo_workdir.clone()).context(
-                                                format!("creating release artifact at {}", tmp.path().display()),
-                                            )?;
+                                            p.create_release_artifact(tmp.path()).context(format!(
+                                                "creating release artifact at {}",
+                                                tmp.path().display()
+                                            ))?;
                                             if dry_run {
                                                 writeln!(&mut out, "    [DRY RUN] Create and publish {}", p.target)?;
                                             } else {
                                                 log::debug!("starting publishing");
-                                                p.publish(repo_workdir.clone()).context("publishing")?;
+                                                p.publish().context("publishing")?;
                                                 log::debug!("finished publishing");
                                                 writeln!(&mut out, "    [NEW] {}", p.target)?;
                                             }


### PR DESCRIPTION
The manifest create & push mechanism is a way of
"promoting images to production", by creating a manifest and pushing it under the
the name of another image, Docker will essentially just re-use the underlying images
to create a new one, under a new namespace. This is *crucial* for us because we
check if Docker releases are missing using the manifests.