### PR TITLE
Brief housekeeping in the SDK

### DIFF
--- a/rust/actyx/node/benches/local_event_roundtrip.rs
+++ b/rust/actyx/node/benches/local_event_roundtrip.rs
@@ -1,7 +1,7 @@
 use actyx_sdk::{
     app_id,
     service::{EventService, Order, PublishEvent, PublishRequest, QueryRequest},
-    tags, AppManifest, HttpClient, Payload,
+    tags, ActyxClient, AppManifest, Payload,
 };
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use futures::StreamExt;
@@ -11,7 +11,7 @@ use tempfile::tempdir;
 use url::Url;
 use util::SocketAddrHelper;
 
-async fn mk_http_client() -> anyhow::Result<HttpClient> {
+async fn mk_http_client() -> anyhow::Result<ActyxClient> {
     let app_manifest = AppManifest::new(
         app_id!("com.example.trial-mode"),
         "display name".into(),
@@ -19,7 +19,7 @@ async fn mk_http_client() -> anyhow::Result<HttpClient> {
         None,
     );
     let url = Url::parse("http://localhost:4454").unwrap();
-    HttpClient::new(url, app_manifest).await
+    ActyxClient::new(url, app_manifest).await
 }
 
 // Note: This doesn't concern itself with any internals (like flushing the send

--- a/rust/actyx/swarm/harness/src/api.rs
+++ b/rust/actyx/swarm/harness/src/api.rs
@@ -1,5 +1,5 @@
 use crate::m;
-use actyx_sdk::{service::EventService, AppManifest, HttpClient, NodeId, Url};
+use actyx_sdk::{service::EventService, ActyxClient, AppManifest, NodeId, Url};
 use anyhow::{anyhow, Result};
 use async_std::task::block_on;
 use netsim_embed::{Machine, Namespace};
@@ -59,7 +59,7 @@ impl Api {
 }
 
 #[derive(Clone)]
-pub struct ApiClient(PinnedResource<HttpClient>);
+pub struct ApiClient(PinnedResource<ActyxClient>);
 impl ApiClient {
     pub fn new(origin: Url, app_manifest: AppManifest, namespace: Namespace) -> Self {
         Self(PinnedResource::new(move || {
@@ -73,7 +73,7 @@ impl ApiClient {
                 Namespace::current().unwrap(),
                 namespace
             );
-            block_on(HttpClient::new(origin, app_manifest)).expect("cannot create")
+            block_on(ActyxClient::new(origin, app_manifest)).expect("cannot create")
         }))
     }
     pub async fn node_id(&self) -> NodeId {

--- a/rust/sdk/README.md
+++ b/rust/sdk/README.md
@@ -23,7 +23,7 @@ in order to see output.
 
 ```no_run
 use actyx_sdk::{
-  app_id, AppManifest, HttpClient,
+  app_id, AppManifest, ActyxClient,
   service::{EventService, Order, QueryRequest, QueryResponse},
 };
 use futures::stream::StreamExt;
@@ -42,7 +42,7 @@ pub async fn main() -> anyhow::Result<()> {
   // Url of the locally running Actyx node
   let url = Url::parse("http://localhost:4454")?;
   // create client for it
-  let service = HttpClient::new(url, app_manifest).await?;
+  let service = ActyxClient::new(url, app_manifest).await?;
 
   // all events matching the given subscription
   // sorted backwards, i.e. youngest to oldest

--- a/rust/sdk/examples/files.rs
+++ b/rust/sdk/examples/files.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use actyx_sdk::{app_id, service::DirectoryChild, AppManifest, HttpClient};
+use actyx_sdk::{app_id, service::DirectoryChild, ActyxClient, AppManifest};
 use asynchronous_codec::{BytesCodec, Framed};
 use futures::{
     future::{try_join_all, BoxFuture},
@@ -15,7 +15,7 @@ use tokio::{fs::File, io::AsyncWriteExt};
 use tokio_util::compat::*;
 use url::Url;
 
-async fn mk_http_client() -> anyhow::Result<HttpClient> {
+async fn mk_http_client() -> anyhow::Result<ActyxClient> {
     let app_manifest = AppManifest::new(
         app_id!("com.example.actyx-offsets"),
         "Offsets Example".into(),
@@ -23,7 +23,7 @@ async fn mk_http_client() -> anyhow::Result<HttpClient> {
         None,
     );
     let url = Url::parse("http://localhost:4454").unwrap();
-    HttpClient::new(url, app_manifest).await
+    ActyxClient::new(url, app_manifest).await
 }
 
 #[derive(StructOpt)]
@@ -99,7 +99,7 @@ pub async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn list_file_or_dir(client: &HttpClient, name_or_cid: String, level: usize) -> BoxFuture<'_, anyhow::Result<()>> {
+fn list_file_or_dir(client: &ActyxClient, name_or_cid: String, level: usize) -> BoxFuture<'_, anyhow::Result<()>> {
     async move {
         let response = client.files_get(&name_or_cid).await?;
         match response {
@@ -124,7 +124,7 @@ fn list_file_or_dir(client: &HttpClient, name_or_cid: String, level: usize) -> B
 }
 
 fn get_file_or_dir(
-    client: HttpClient,
+    client: ActyxClient,
     name_or_cid: String,
     write_to: PathBuf,
 ) -> BoxFuture<'static, anyhow::Result<()>> {

--- a/rust/sdk/examples/publish.rs
+++ b/rust/sdk/examples/publish.rs
@@ -1,7 +1,7 @@
 use actyx_sdk::{
     app_id,
     service::{EventService, PublishEvent, PublishRequest},
-    tags, AppManifest, HttpClient, Payload,
+    tags, ActyxClient, AppManifest, Payload,
 };
 use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
 use url::Url;
@@ -10,7 +10,7 @@ fn counter() -> impl Stream<Item = i32> {
     stream::iter(0..).then(|i| futures_timer::Delay::new(std::time::Duration::from_secs(1)).map(move |()| i))
 }
 
-async fn mk_http_client() -> anyhow::Result<HttpClient> {
+async fn mk_http_client() -> anyhow::Result<ActyxClient> {
     let app_manifest = AppManifest::new(
         app_id!("com.example.actyx-publish"),
         "Publish Example".into(),
@@ -18,7 +18,7 @@ async fn mk_http_client() -> anyhow::Result<HttpClient> {
         None,
     );
     let url = Url::parse("http://localhost:4454").unwrap();
-    HttpClient::new(url, app_manifest).await
+    ActyxClient::new(url, app_manifest).await
 }
 
 #[tokio::main]

--- a/rust/sdk/examples/query.rs
+++ b/rust/sdk/examples/query.rs
@@ -1,12 +1,12 @@
 use actyx_sdk::{
     app_id,
     service::{EventService, Order, QueryRequest, QueryResponse},
-    AppManifest, HttpClient,
+    ActyxClient, AppManifest,
 };
 use futures::stream::StreamExt;
 use url::Url;
 
-async fn mk_http_client() -> anyhow::Result<HttpClient> {
+async fn mk_http_client() -> anyhow::Result<ActyxClient> {
     let app_manifest = AppManifest::new(
         app_id!("com.example.actyx-offsets"),
         "Offsets Example".into(),
@@ -14,7 +14,7 @@ async fn mk_http_client() -> anyhow::Result<HttpClient> {
         None,
     );
     let url = Url::parse("http://localhost:4454").unwrap();
-    HttpClient::new(url, app_manifest).await
+    ActyxClient::new(url, app_manifest).await
 }
 
 #[tokio::main]

--- a/rust/sdk/src/arb.rs
+++ b/rust/sdk/src/arb.rs
@@ -1,3 +1,7 @@
+// Used by trees::arb
+// Can't really be moved to `trees` since Rust disallows
+// implementing foreign traits on foreign types
+
 use std::collections::BTreeMap;
 
 use crate::{

--- a/rust/sdk/src/client.rs
+++ b/rust/sdk/src/client.rs
@@ -261,6 +261,12 @@ impl Debug for ActyxClient {
 
 #[async_trait]
 impl EventService for ActyxClient {
+    /// Returns known offsets across local and replicated streams.
+    ///
+    /// If an authorization error (code 401) is returned, it will try to re-authenticate.
+    /// If the service is unavailable (code 503), this method will retry to perform the
+    /// request up to 10 times with exponentially increasing delay - currently,
+    /// this behavior is only available if the `with-tokio` feature is enabled.
     async fn offsets(&self) -> anyhow::Result<OffsetsResponse> {
         let response = self.do_request(|c| c.get(self.events_url("offsets"))).await?;
         let bytes = response
@@ -276,6 +282,12 @@ impl EventService for ActyxClient {
         })?)
     }
 
+    /// Publishes a set of new events.
+    ///
+    /// If an authorization error (code 401) is returned, it will try to re-authenticate.
+    /// If the service is unavailable (code 503), this method will retry to perform the
+    /// request up to 10 times with exponentially increasing delay - currently,
+    /// this behavior is only available if the `with-tokio` feature is enabled.
     async fn publish(&self, request: PublishRequest) -> anyhow::Result<PublishResponse> {
         let body = serde_json::to_value(&request).context(|| format!("serializing {:?}", &request))?;
         let response = self
@@ -294,6 +306,12 @@ impl EventService for ActyxClient {
         })?)
     }
 
+    /// Query events known at the time the request was received by the service.
+    ///
+    /// If an authorization error (code 401) is returned, it will try to re-authenticate.
+    /// If the service is unavailable (code 503), this method will retry to perform the
+    /// request up to 10 times with exponentially increasing delay - currently,
+    /// this behavior is only available if the `with-tokio` feature is enabled.
     async fn query(&self, request: QueryRequest) -> anyhow::Result<BoxStream<'static, QueryResponse>> {
         let body = serde_json::to_value(&request).context(|| format!("serializing {:?}", &request))?;
         let response = self
@@ -306,6 +324,12 @@ impl EventService for ActyxClient {
         Ok(res.boxed())
     }
 
+    /// Suscribe to events that are currently known by the service followed by new "live" events.
+    ///
+    /// If an authorization error (code 401) is returned, it will try to re-authenticate.
+    /// If the service is unavailable (code 503), this method will retry to perform the
+    /// request up to 10 times with exponentially increasing delay - currently,
+    /// this behavior is only available if the `with-tokio` feature is enabled.
     async fn subscribe(&self, request: SubscribeRequest) -> anyhow::Result<BoxStream<'static, SubscribeResponse>> {
         let body = serde_json::to_value(&request).context(|| format!("serializing {:?}", &request))?;
         let response = self
@@ -318,6 +342,13 @@ impl EventService for ActyxClient {
         Ok(res.boxed())
     }
 
+    /// Subscribe to events that are currently known by the service followed by new "live" events until
+    /// the service learns about events that need to be sorted earlier than an event already received.
+    ///
+    /// If an authorization error (code 401) is returned, it will try to re-authenticate.
+    /// If the service is unavailable (code 503), this method will retry to perform the
+    /// request up to 10 times with exponentially increasing delay - currently,
+    /// this behavior is only available if the `with-tokio` feature is enabled.
     async fn subscribe_monotonic(
         &self,
         request: SubscribeMonotonicRequest,

--- a/rust/sdk/src/client.rs
+++ b/rust/sdk/src/client.rs
@@ -39,14 +39,14 @@ use rand::Rng;
 #[derive(Clone, Debug, Error, Display, Serialize, Deserialize, PartialEq, Eq)]
 #[display(fmt = "error {} while {}: {}", error_code, context, error)]
 #[serde(rename_all = "camelCase")]
-pub struct HttpClientError {
+pub struct ActyxClientError {
     pub error: serde_json::Value,
     pub error_code: u16,
     pub context: String,
 }
 
 #[derive(Clone)]
-pub struct HttpClient {
+pub struct ActyxClient {
     client: Client,
     base_url: Url,
     token: Arc<RwLock<String>>,
@@ -66,7 +66,7 @@ async fn get_token(client: &Client, base_url: &Url, app_manifest: &AppManifest) 
     Ok(token.token)
 }
 
-impl HttpClient {
+impl ActyxClient {
     /// Configures connection to Actyx node with provided Url and AppManifest.
     /// All path segments of the Url (if any) are discarded.
     pub async fn new(origin: Url, app_manifest: AppManifest) -> anyhow::Result<Self> {
@@ -187,7 +187,7 @@ impl HttpClient {
             Ok(response)
         } else {
             let error_code = response.status().as_u16();
-            Err(HttpClientError {
+            Err(ActyxClientError {
                 error: response
                     .json()
                     .await
@@ -211,7 +211,7 @@ impl HttpClient {
             .text_with_charset("utf-8")
             .await
             .context(|| "Parsing response".to_string())?;
-        let cid = Cid::from_str(&hash).map_err(|e| HttpClientError {
+        let cid = Cid::from_str(&hash).map_err(|e| ActyxClientError {
             error: serde_json::Value::String(e.to_string()),
             error_code: 102,
             context: format!("Tried to parse {} into a Cid", hash),
@@ -250,9 +250,9 @@ impl HttpClient {
     }
 }
 
-impl Debug for HttpClient {
+impl Debug for ActyxClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HttpClient")
+        f.debug_struct("ActyxClient")
             .field("base_url", &self.base_url.as_str())
             .field("app_manifest", &self.app_manifest)
             .finish()
@@ -260,7 +260,7 @@ impl Debug for HttpClient {
 }
 
 #[async_trait]
-impl EventService for HttpClient {
+impl EventService for ActyxClient {
     async fn offsets(&self) -> anyhow::Result<OffsetsResponse> {
         let response = self.do_request(|c| c.get(self.events_url("offsets"))).await?;
         let bytes = response
@@ -366,9 +366,9 @@ pub(crate) trait WithContext {
 }
 impl<T, E> WithContext for std::result::Result<T, E>
 where
-    HttpClientError: From<(String, E)>,
+    ActyxClientError: From<(String, E)>,
 {
-    type Output = std::result::Result<T, HttpClientError>;
+    type Output = std::result::Result<T, ActyxClientError>;
 
     #[inline]
     fn context<F, C>(self, context: F) -> Self::Output
@@ -378,12 +378,12 @@ where
     {
         match self {
             Ok(value) => Ok(value),
-            Err(err) => Err(HttpClientError::from((context().into(), err))),
+            Err(err) => Err(ActyxClientError::from((context().into(), err))),
         }
     }
 }
 
-impl From<(String, reqwest::Error)> for HttpClientError {
+impl From<(String, reqwest::Error)> for ActyxClientError {
     fn from(e: (String, reqwest::Error)) -> Self {
         Self {
             error: serde_json::json!(format!("{:?}", e.1)),
@@ -393,7 +393,7 @@ impl From<(String, reqwest::Error)> for HttpClientError {
     }
 }
 
-impl From<(String, serde_json::Error)> for HttpClientError {
+impl From<(String, serde_json::Error)> for ActyxClientError {
     fn from(e: (String, serde_json::Error)) -> Self {
         Self {
             error: serde_json::json!(format!("{:?}", e.1)),
@@ -403,7 +403,7 @@ impl From<(String, serde_json::Error)> for HttpClientError {
     }
 }
 
-impl From<(String, serde_cbor::Error)> for HttpClientError {
+impl From<(String, serde_cbor::Error)> for ActyxClientError {
     fn from(e: (String, serde_cbor::Error)) -> Self {
         Self {
             error: serde_json::json!(format!("{:?}", e.1)),

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -19,9 +19,9 @@ mod scalar;
 mod app_manifest;
 #[cfg(any(test, feature = "arb"))]
 pub mod arb;
-mod event;
 #[cfg(feature = "client")]
-mod http_client;
+mod client;
+mod event;
 pub mod language;
 pub mod legacy;
 mod offset;
@@ -32,9 +32,9 @@ mod timestamp;
 pub mod types;
 
 pub use app_manifest::AppManifest;
-pub use event::{Event, EventKey, Metadata, Opaque, Payload};
 #[cfg(feature = "client")]
-pub use http_client::HttpClient;
+pub use client::ActyxClient;
+pub use event::{Event, EventKey, Metadata, Opaque, Payload};
 pub use offset::{Offset, OffsetError, OffsetMap, OffsetOrMin};
 pub use scalars::{AppId, NodeId, StreamId, StreamNr};
 pub use tags::{Tag, TagSet};

--- a/rust/sdk/src/service/events.rs
+++ b/rust/sdk/src/service/events.rs
@@ -514,7 +514,7 @@ pub trait EventService: Clone + Send {
     /// Publishes a set of new events.
     async fn publish(&self, request: PublishRequest) -> Result<PublishResponse>;
 
-    /// Query events known at the time the request was reveived by the service.
+    /// Query events known at the time the request was received by the service.
     async fn query(&self, request: QueryRequest) -> Result<BoxStream<'static, QueryResponse>>;
 
     /// Suscribe to events that are currently known by the service followed by new "live" events.


### PR DESCRIPTION
- Rename the `HttpClient` to `ActyxClient`
- Remove the thread-based exponential backoff