### PR TITLE
fold ax-cert into ax plus improvements

### DIFF
--- a/rust/actyx/ax/Cargo.toml
+++ b/rust/actyx/ax/Cargo.toml
@@ -40,6 +40,7 @@ libp2p-streaming-response = { path = "../libp2p-streaming-response" }
 maplit = "1.0.2"
 prettytable-rs = "0.8.0"
 rand = "0.8.4"
+regex = "1.5.4"
 runtime = { path = "../runtime" }
 serde = "1.0.133"
 serde_json = "1.0.74"

--- a/rust/actyx/ax/src/cmd/apps/mod.rs
+++ b/rust/actyx/ax/src/cmd/apps/mod.rs
@@ -1,15 +1,20 @@
+mod license;
 mod sign;
 
 use crate::cmd::AxCliCommand;
 use futures::Future;
 use structopt::StructOpt;
 
+use license::LicenseOpts;
 pub use sign::{create_signed_app_manifest, SignOpts};
 
 #[derive(StructOpt, Debug)]
 #[structopt(version = env!("AX_CLI_VERSION"))]
 /// manage app manifests
 pub enum AppsOpts {
+    #[structopt(no_version)]
+    /// Create app or node license
+    License(LicenseOpts),
     #[structopt(no_version)]
     /// Sign application manifest
     Sign(SignOpts),
@@ -18,5 +23,6 @@ pub enum AppsOpts {
 pub fn run(opts: AppsOpts, json: bool) -> Box<dyn Future<Output = ()> + Unpin> {
     match opts {
         AppsOpts::Sign(opt) => sign::AppsSign::output(opt, json),
+        AppsOpts::License(opt) => license::AppsLicense::output(opt, json),
     }
 }

--- a/rust/actyx/ax/src/cmd/mod.rs
+++ b/rust/actyx/ax/src/cmd/mod.rs
@@ -67,7 +67,7 @@ pub struct ConsoleOpt {
     #[structopt(name = "NODE", required = true)]
     /// the IP address or <host>:<admin port> of the node to perform the operation on.
     authority: Authority,
-    #[structopt(short, long, value_name = "FILE")]
+    #[structopt(short, long, value_name = "FILE_OR_KEY", env = "AX_IDENTITY", hide_env_values = true)]
     /// File from which the identity (private key) for authentication is read.
     identity: Option<KeyPathWrapper>,
 }
@@ -104,7 +104,11 @@ impl TryFrom<&Option<KeyPathWrapper>> for AxPrivateKey {
     type Error = ActyxOSError;
     fn try_from(k: &Option<KeyPathWrapper>) -> Result<AxPrivateKey> {
         if let Some(path) = k {
-            AxPrivateKey::from_file(&path.0)
+            path.0
+                .to_str()
+                .and_then(|s| s.parse::<AxPrivateKey>().ok())
+                .ok_or(ActyxOSError::internal(""))
+                .or_else(|_| AxPrivateKey::from_file(&path.0))
         } else {
             let private_key_path = AxPrivateKey::default_user_identity_path()?;
             AxPrivateKey::from_file(&private_key_path).map_err(move |e| {

--- a/rust/actyx/ax/src/cmd/users/addkey.rs
+++ b/rust/actyx/ax/src/cmd/users/addkey.rs
@@ -78,7 +78,7 @@ pub struct AddKeyOpts {
     #[structopt(name = "PATH", required = true)]
     /// Path to the `actyx-data` folder you wish to modify
     path: PathBuf,
-    #[structopt(short, long, value_name = "FILE")]
+    #[structopt(short, long, value_name = "FILE_OR_KEY", env = "AX_IDENTITY", hide_env_values = true)]
     /// File from which the identity (private key) for authentication is read.
     identity: Option<KeyPathWrapper>,
 }

--- a/rust/actyx/ax/src/cmd/users/devcert.rs
+++ b/rust/actyx/ax/src/cmd/users/devcert.rs
@@ -1,0 +1,46 @@
+use crate::cmd::AxCliCommand;
+use certs::{AppDomain, DeveloperCertificateInput, ManifestDeveloperCertificate};
+use crypto::{PrivateKey, PublicKey};
+use futures::{stream::once, FutureExt, Stream};
+use structopt::StructOpt;
+use util::formats::{ActyxOSCode, ActyxOSResult, ActyxOSResultExt};
+
+#[derive(StructOpt, Debug)]
+#[structopt(version = env!("AX_CLI_VERSION"))]
+pub struct DevCertOpts {
+    /// The secret key used to sign the certificate
+    /// (this must match the AX_PUBLIC_KEY your `actyx` binary has been compiled with).
+    #[structopt(long, short = "A", env, hide_env_values = true)]
+    ax_secret_key: PrivateKey,
+
+    /// The developer's public key.
+    #[structopt(long, short)]
+    dev_public_key: PublicKey,
+
+    /// The app id domains for which to certify the developer.
+    #[structopt(long, short)]
+    app_domains: Vec<AppDomain>,
+}
+
+pub struct UsersDevCert;
+
+impl AxCliCommand for UsersDevCert {
+    type Opt = DevCertOpts;
+    type Output = String;
+
+    fn run(opts: Self::Opt) -> Box<dyn Stream<Item = ActyxOSResult<Self::Output>> + Unpin> {
+        Box::new(once(
+            async move {
+                let input = DeveloperCertificateInput::new(opts.dev_public_key, opts.app_domains);
+                let dev_cert = ManifestDeveloperCertificate::new(input, opts.ax_secret_key)
+                    .ax_err(ActyxOSCode::ERR_INTERNAL_ERROR)?;
+                serde_json::to_string(&dev_cert).ax_err(ActyxOSCode::ERR_INTERNAL_ERROR)
+            }
+            .boxed(),
+        ))
+    }
+
+    fn pretty(result: Self::Output) -> String {
+        result
+    }
+}

--- a/rust/actyx/ax/src/cmd/users/mod.rs
+++ b/rust/actyx/ax/src/cmd/users/mod.rs
@@ -1,27 +1,40 @@
 mod addkey;
+mod devcert;
 mod keygen;
+mod pubkey;
 
 use crate::cmd::AxCliCommand;
-use addkey::AddKeyOpts;
 use futures::Future;
-use keygen::KeygenOpts;
 use structopt::StructOpt;
+
+use addkey::AddKeyOpts;
+use devcert::DevCertOpts;
+use keygen::KeygenOpts;
+use pubkey::PubkeyOpts;
 
 #[derive(StructOpt, Debug)]
 #[structopt(version = env!("AX_CLI_VERSION"))]
 /// manage user keys
 pub enum UsersOpts {
     #[structopt(no_version)]
-    /// Generate a new user key pair for interacting with an Actyx node.
+    /// Install a user key into /admin/authorizedUsers of a local Actyx node that is not currently running.
     AddKey(AddKeyOpts),
     #[structopt(no_version)]
     /// Generate a new user key pair for interacting with an Actyx node.
     Keygen(KeygenOpts),
+    #[structopt(no_version)]
+    /// Show public key corresponding to a private key.
+    Pubkey(PubkeyOpts),
+    #[structopt(no_version)]
+    /// Generate a new developer certificate.
+    DevCert(DevCertOpts),
 }
 
 pub fn run(opts: UsersOpts, json: bool) -> Box<dyn Future<Output = ()> + Unpin> {
     match opts {
         UsersOpts::Keygen(opt) => keygen::UsersKeygen::output(opt, json),
         UsersOpts::AddKey(opt) => addkey::UsersAddKey::output(opt, json),
+        UsersOpts::DevCert(opt) => devcert::UsersDevCert::output(opt, json),
+        UsersOpts::Pubkey(opt) => pubkey::UsersPubkey::output(opt, json),
     }
 }

--- a/rust/actyx/ax/src/cmd/users/pubkey.rs
+++ b/rust/actyx/ax/src/cmd/users/pubkey.rs
@@ -1,0 +1,33 @@
+use crate::{
+    cmd::{AxCliCommand, KeyPathWrapper},
+    private_key::AxPrivateKey,
+};
+use crypto::PublicKey;
+use futures::{stream::once, FutureExt, Stream};
+use structopt::StructOpt;
+use util::formats::ActyxOSResult;
+
+#[derive(StructOpt, Debug)]
+#[structopt(version = env!("AX_CLI_VERSION"))]
+pub struct PubkeyOpts {
+    #[structopt(short, long, value_name = "FILE_OR_KEY", env = "AX_IDENTITY", hide_env_values = true)]
+    /// File from which the identity (private key) for authentication is read.
+    identity: Option<KeyPathWrapper>,
+}
+
+pub struct UsersPubkey;
+
+impl AxCliCommand for UsersPubkey {
+    type Opt = PubkeyOpts;
+    type Output = PublicKey;
+
+    fn run(opts: Self::Opt) -> Box<dyn Stream<Item = ActyxOSResult<Self::Output>> + Unpin> {
+        Box::new(once(
+            async move { AxPrivateKey::try_from(&opts.identity).map(|p| p.to_public()) }.boxed(),
+        ))
+    }
+
+    fn pretty(result: Self::Output) -> String {
+        result.to_string()
+    }
+}

--- a/rust/actyx/ax/src/private_key.rs
+++ b/rust/actyx/ax/src/private_key.rs
@@ -110,6 +110,10 @@ impl AxPrivateKey {
         let crypto_kp: KeyPair = self.0.into();
         identity::Keypair::from(crypto_kp)
     }
+
+    pub(crate) fn to_private(&self) -> PrivateKey {
+        self.0
+    }
 }
 impl FromStr for AxPrivateKey {
     type Err = anyhow::Error;

--- a/rust/actyx/certs/src/lib.rs
+++ b/rust/actyx/certs/src/lib.rs
@@ -7,7 +7,7 @@ mod trial_app_manifest;
 
 pub use app_domain::AppDomain;
 pub use app_license::{AppLicense, AppLicenseType, Expiring, RequesterInfo, SignedAppLicense};
-pub use developer_certificate::{DeveloperCertificate, ManifestDeveloperCertificate};
+pub use developer_certificate::{DeveloperCertificate, DeveloperCertificateInput, ManifestDeveloperCertificate};
 pub use signed_app_manifest::SignedAppManifest;
 pub use trial_app_manifest::TrialAppManifest;
 


### PR DESCRIPTION
feat(cli): add generation of licenses and developer certificates
feat(cli): use AX_IDENTITY environment variable when -i is not given
feat(cli): allow passing of private key instead of identity filename
