### PR TITLE
Remove the StartFrom abstraction and add doc to SubscribeMonotonic

### DIFF
--- a/rust/actyx/api/src/events/service.rs
+++ b/rust/actyx/api/src/events/service.rs
@@ -4,7 +4,7 @@ use actyx_sdk::{
     language::{self, Arr, SimpleExpr, SpreadExpr},
     service::{
         Diagnostic, OffsetMapResponse, OffsetsResponse, Order, PublishEvent, PublishRequest, PublishResponse,
-        PublishResponseKey, QueryRequest, QueryResponse, Severity, StartFrom, SubscribeMonotonicRequest,
+        PublishResponseKey, QueryRequest, QueryResponse, Severity, SubscribeMonotonicRequest,
         SubscribeMonotonicResponse, SubscribeRequest, SubscribeResponse,
     },
     AppId, Event, EventKey, NodeId, OffsetMap, OffsetOrMin, Payload, TagSet, Timestamp,
@@ -394,9 +394,7 @@ impl EventService {
                 .into())
             }
         };
-        let mut lower_bound = match &request.from {
-            StartFrom::LowerBound(x) => x.clone(),
-        };
+        let mut lower_bound = request.from.clone();
         let mut present = self.store.offsets().await?.present();
         present.union_with(&lower_bound);
 
@@ -427,21 +425,19 @@ impl EventService {
             .unbounded_forward(tag_expr.clone(), lower_bound)
             .await?
             .stop_on_error();
-        let mut latest = match &request.from {
-            StartFrom::LowerBound(offsets) => self
-                .store
-                .bounded_backward(tag_expr, OffsetMap::default(), offsets.clone())
-                .await?
-                .recv()
-                .await
-                .transpose()?
-                .map(|event| event.key)
-                .unwrap_or(EventKey {
-                    lamport: 0.into(),
-                    stream: Default::default(),
-                    offset: 0.into(),
-                }),
-        };
+        let mut latest = self
+            .store
+            .bounded_backward(tag_expr, OffsetMap::default(), request.from.clone())
+            .await?
+            .recv()
+            .await
+            .transpose()?
+            .map(|event| event.key)
+            .unwrap_or(EventKey {
+                lamport: 0.into(),
+                stream: Default::default(),
+                offset: 0.into(),
+            });
 
         async fn send_and_timetravel(
             co: &Co<SubscribeMonotonicResponse>,

--- a/rust/actyx/api/src/events/service.rs
+++ b/rust/actyx/api/src/events/service.rs
@@ -394,7 +394,7 @@ impl EventService {
                 .into())
             }
         };
-        let mut lower_bound = request.from.clone();
+        let mut lower_bound = request.lower_bound.clone();
         let mut present = self.store.offsets().await?.present();
         present.union_with(&lower_bound);
 
@@ -427,7 +427,7 @@ impl EventService {
             .stop_on_error();
         let mut latest = self
             .store
-            .bounded_backward(tag_expr, OffsetMap::default(), request.from.clone())
+            .bounded_backward(tag_expr, OffsetMap::default(), request.lower_bound.clone())
             .await?
             .recv()
             .await
@@ -791,7 +791,7 @@ mod tests {
                 SubscribeMonotonicRequest {
                     query: q.to_owned(),
                     session: SessionId::from("wat"),
-                    from: StartFrom::LowerBound(OffsetMap::empty()),
+                    lower_bound: OffsetMap::empty(),
                 },
             )
             .await

--- a/rust/actyx/ax/src/cmd/internal/events/subscribe_monotonic.rs
+++ b/rust/actyx/ax/src/cmd/internal/events/subscribe_monotonic.rs
@@ -2,10 +2,7 @@ use crate::{
     cmd::{AxCliCommand, ConsoleOpt},
     node_connection::{request_events, EventDiagnostic},
 };
-use actyx_sdk::{
-    service::{StartFrom, SubscribeMonotonicRequest},
-    OffsetMap,
-};
+use actyx_sdk::{service::SubscribeMonotonicRequest, OffsetMap};
 use futures::{future::ready, Stream, StreamExt};
 use structopt::StructOpt;
 use util::{
@@ -36,7 +33,7 @@ impl AxCliCommand for EventsSubscribeMonotonic {
                 peer,
                 EventsRequest::SubscribeMonotonic(SubscribeMonotonicRequest {
                     session: "".into(),
-                    from: StartFrom::LowerBound(OffsetMap::default()),
+                    lower_bound: OffsetMap::default(),
                     query: opts.query,
                 }),
             )

--- a/rust/actyx/util/src/formats/events_protocol.rs
+++ b/rust/actyx/util/src/formats/events_protocol.rs
@@ -56,9 +56,7 @@ pub enum EventsResponse {
 mod tests {
     use super::*;
     use actyx_sdk::{
-        app_id,
-        service::{Severity, StartFrom},
-        tags, Event, EventKey, LamportTimestamp, Metadata, NodeId, Offset, Timestamp,
+        app_id, service::Severity, tags, Event, EventKey, LamportTimestamp, Metadata, NodeId, Offset, Timestamp,
     };
     use std::collections::BTreeMap;
 
@@ -92,7 +90,7 @@ mod tests {
         assert_eq!(
             req(EventsRequest::SubscribeMonotonic(SubscribeMonotonicRequest {
                 session: "".into(),
-                from: StartFrom::LowerBound(OffsetMap::default()),
+                lower_bound: OffsetMap::default(),
                 query: "FROM allEvents".parse().unwrap(),
             })),
             r#"{"type":"subscribeMonotonic","query":"FROM allEvents","session":"","lowerBound":{}}"#

--- a/rust/sdk/examples/query_bounds.rs
+++ b/rust/sdk/examples/query_bounds.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
     let service = Ax::new(AxOpts::default()).await?;
 
     // Publish the events
-    service
+    let publish_response = service
         .publish()
         .event(
             tags!("temperature", "sensor:temp-sensor1"),

--- a/rust/sdk/examples/subscribe_monotonic.rs
+++ b/rust/sdk/examples/subscribe_monotonic.rs
@@ -1,4 +1,4 @@
-use actyx_sdk::{Ax, AxOpts};
+use actyx_sdk::{service::QueryResponse, Ax, AxOpts};
 use futures::StreamExt;
 
 // This example demonstrates how to subscribe to a query.
@@ -7,8 +7,14 @@ async fn main() {
     // Setup a default Ax client with default settings.
     let service = Ax::new(AxOpts::default()).await.unwrap();
 
+    let offsets = service.offsets().await.unwrap().present;
+
     // Start a subscription, receiving only events tagged with `example:tag`
-    let mut subscribe_response = service.subscribe("FROM 'example:tag'").await.unwrap();
+    let mut subscribe_response = service
+        .subscribe_monotonic("FROM 'sensor:temp-sensor1'")
+        .with_lower_bound(offsets)
+        .await
+        .unwrap();
 
     // Consume events from the subscription stream
     while let Some(response) = subscribe_response.next().await {

--- a/rust/sdk/src/service/events.rs
+++ b/rust/sdk/src/service/events.rs
@@ -343,14 +343,6 @@ pub struct PublishResponse {
     pub data: Vec<PublishResponseKey>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialOrd, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum StartFrom {
-    /// If the lower bound is given in, it filters out all events that are included
-    /// in the offset map.
-    LowerBound(OffsetMap),
-}
-
 /// The session identifier used in /subscribe_monotonic
 #[derive(Debug, Clone, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct SessionId(Box<str>);
@@ -402,8 +394,7 @@ pub struct SubscribeMonotonicRequest {
     /// previously interrupted stream. In this case, StartFrom::Offsets is used,
     /// otherwise StartFrom::Snapshot indicates that the PondService shall figure
     /// out where best to start out from, possibly sending a `State` message first.
-    #[serde(flatten)]
-    pub from: StartFrom,
+    pub from: OffsetMap,
 }
 
 /// The response to a monotonic subscription is a stream of events terminated by a time travel.

--- a/rust/sdk/src/service/events.rs
+++ b/rust/sdk/src/service/events.rs
@@ -394,7 +394,7 @@ pub struct SubscribeMonotonicRequest {
     /// previously interrupted stream. In this case, StartFrom::Offsets is used,
     /// otherwise StartFrom::Snapshot indicates that the PondService shall figure
     /// out where best to start out from, possibly sending a `State` message first.
-    pub from: OffsetMap,
+    pub lower_bound: OffsetMap,
 }
 
 /// The response to a monotonic subscription is a stream of events terminated by a time travel.

--- a/rust/sdk/tests/serialization_roundtrips.rs
+++ b/rust/sdk/tests/serialization_roundtrips.rs
@@ -1,15 +1,14 @@
 use actyx_sdk::service::*;
 use serde_json::*;
 
-fn roundtrip<T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug>(json: Value) -> anyhow::Result<()> {
-    let value: T = from_value(json.clone())?;
-    let serialized = to_value(value)?;
-    anyhow::ensure!(json == serialized, "\nleft:  {:?}\nright: {:?}", json, serialized);
-    Ok(())
+fn roundtrip<T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug>(json: Value) {
+    let value: T = from_value(json.clone()).unwrap();
+    let serialized = to_value(value).unwrap();
+    assert_eq!(json, serialized)
 }
 
 #[test]
-fn roundtrips() -> anyhow::Result<()> {
+fn roundtrip_offsets_response() {
     roundtrip::<OffsetsResponse>(json!({
       "present": {
         "1g1UOqdpvBB1KHsGWGZiK3Vi8MYGDZZ1oylpOajUk.s-2": 56
@@ -17,8 +16,11 @@ fn roundtrips() -> anyhow::Result<()> {
       "toReplicate": {
         "1g1UOqdpvBB1KHsGWGZiK3Vi8MYGDZZ1oylpOajUk.s-2": 1
       }
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_publish_request() {
     roundtrip::<PublishRequest>(json!({
       "data": [
         {
@@ -34,8 +36,11 @@ fn roundtrips() -> anyhow::Result<()> {
           }
         }
       ]
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_publish_response() {
     roundtrip::<PublishResponse>(json!({
       "data": [
         {
@@ -51,8 +56,11 @@ fn roundtrips() -> anyhow::Result<()> {
           "timestamp": 1622110001582587u64
         }
       ]
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_query_request() {
     roundtrip::<QueryRequest>(json!({
       "lowerBound": {
         "1g1UOqdpvBB1KHsGWGZiK3Vi8MYGDZZ1oylpOajUk.s-2": 34
@@ -62,8 +70,11 @@ fn roundtrips() -> anyhow::Result<()> {
       },
       "query": "FROM ('tag-01' & ('tag-02' | 'tag-03')) END",
       "order": "desc"
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_query_response() {
     roundtrip::<QueryResponse>(json!({
       "type": "event",
       "lamport": 28,
@@ -75,15 +86,21 @@ fn roundtrips() -> anyhow::Result<()> {
       "payload": {
         "value": 2
       }
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_subscribe_request() {
     roundtrip::<SubscribeRequest>(json!({
       "lowerBound": {
         "1g1UOqdpvBB1KHsGWGZiK3Vi8MYGDZZ1oylpOajUk.s-2": 34,
       },
       "query": "FROM ('tag-01' & ('tag-02' | 'tag-03')) END",
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_subscribe_response() {
     roundtrip::<SubscribeResponse>(json!({
       "type": "event",
       "lamport": 28,
@@ -95,16 +112,22 @@ fn roundtrips() -> anyhow::Result<()> {
       "payload": {
         "value": 2
       }
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_subscribe_monotonic_request() {
     roundtrip::<SubscribeMonotonicRequest>(json!({
       "session": "my_session_id",
       "query": "FROM ('tag-01' & ('tag-02' | 'tag-03')) END",
       "lowerBound": {
         "1g1UOqdpvBB1KHsGWGZiK3Vi8MYGDZZ1oylpOajUk.s-2": 34
       }
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_subscribe_monotonic_timetravel() {
     roundtrip::<SubscribeMonotonicResponse>(json!({
       "type": "timeTravel",
       "newStart": {
@@ -112,8 +135,11 @@ fn roundtrips() -> anyhow::Result<()> {
         "stream": "1g1UOqdpvBB1KHsGWGZiK3Vi8MYGDZZ1oylpOajUk.s-2",
         "offset": 34
       }
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_subscribe_monotonic_event() {
     roundtrip::<SubscribeMonotonicResponse>(json!({
       "type": "event",
       "lamport": 323,
@@ -127,8 +153,11 @@ fn roundtrips() -> anyhow::Result<()> {
         "fooArr": ["bar1", "bar2"]
       },
       "caughtUp": true
-    }))?;
+    }))
+}
 
+#[test]
+fn roundtrip_node_info_response() {
     roundtrip::<NodeInfoResponse>(json!({
       "connectedNodes": 12,
       "uptime": {
@@ -142,7 +171,4 @@ fn roundtrips() -> anyhow::Result<()> {
         }
       }
     }))
-    .unwrap();
-
-    Ok(())
 }


### PR DESCRIPTION
closes #582 

There's still info missing and I think the bounds examples may be poorly documented because querying for a specific event in the middle of something doesn't yield the last offset of that event, it still sends the present; as seen in: https://github.com/Actyx/Actyx/blob/3c85d303451d0e9e20404c06742e1fc323751aef/rust/actyx/api/src/events/service.rs#L122-L125