### PR TITLE
Remove postgres code from SDK

### DIFF
--- a/rust/sdk/Cargo.lock
+++ b/rust/sdk/Cargo.lock
@@ -27,7 +27,6 @@ dependencies = [
  "once_cell",
  "pest",
  "pest_derive",
- "postgres-types",
  "quickcheck",
  "quickcheck_derive",
  "rand",
@@ -448,7 +447,6 @@ checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -732,15 +730,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -1048,15 +1037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "md-5"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,35 +1341,6 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
-
-[[package]]
-name = "postgres-protocol"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
-dependencies = [
- "base64",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "hmac",
- "md-5",
- "memchr",
- "rand",
- "sha2",
- "stringprep",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d946ec7d256b04dfadc4e6a3292324e6f417124750fc5c0950f981b703a0f1"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "postgres-protocol",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1753,17 +1704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,16 +1739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stringprep"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,12 +1767,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -19,7 +19,6 @@ features = ["client"]
 default = ["client"]
 client = ["reqwest", "url", "bytes", "rand"]
 sqlite = ["rusqlite"]
-postgresql = ["postgres-types", "bytes"]
 arb = ["quickcheck", "rand"]
 with-tokio = ["tokio"]
 
@@ -45,7 +44,6 @@ num-traits = "0.2.14"
 once_cell = "1.9.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-postgres-types = { version = "0.2.2", optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 rand = { version = "0.8.4", optional = true }
 reqwest = { version = "0.11.8", features = [

--- a/rust/sdk/src/offset.rs
+++ b/rust/sdk/src/offset.rs
@@ -428,44 +428,6 @@ mod sqlite {
     }
 }
 
-#[cfg(feature = "postgresql")]
-mod postgresql {
-    use super::*;
-    use bytes::BytesMut;
-    use postgres_types::{FromSql, IsNull, ToSql, Type};
-
-    impl<'a> FromSql<'a> for Offset {
-        fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-            i64::from_sql(ty, raw).and_then(|o| Offset::try_from(o).map_err(|e| e.into()))
-        }
-        fn accepts(ty: &Type) -> bool {
-            <i64 as FromSql>::accepts(ty)
-        }
-    }
-
-    impl ToSql for Offset {
-        fn accepts(ty: &Type) -> bool
-        where
-            Self: Sized,
-        {
-            <i64 as ToSql>::accepts(ty)
-        }
-        fn to_sql_checked(
-            &self,
-            ty: &Type,
-            out: &mut BytesMut,
-        ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
-            self.0.to_sql_checked(ty, out)
-        }
-        fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>>
-        where
-            Self: Sized,
-        {
-            self.0.to_sql(ty, out)
-        }
-    }
-}
-
 /// Multi-dimensional cursor for event streams: an `OffsetMap` describes the set of events
 /// given by the event streams of each included source up to the associated [`Offset`](struct.Offset.html).
 ///


### PR DESCRIPTION
We will also be able to remove SQLite from the SDK once we remove the old-formats as well