### PR TITLE
Update the discord workflow notification action

### DIFF
--- a/.github/workflows/artifacts-and-rc.yml
+++ b/.github/workflows/artifacts-and-rc.yml
@@ -369,7 +369,7 @@ jobs:
       - create-release-candidate
 
     steps:
-      - uses: jmg-duarte/discord-workflow-status@83dc78bf9ece4963250e5b73da83c06638c7a3bf
+      - uses: jmg-duarte/discord-workflow-status@0c3c34d89f51c8ff5d8dd9662b8a850579fb00fb
         with:
           # GitHub actions does not allow secrets to be used in `if` clauses
           # hence, instead of using an env variable, checking in the `if` and then

--- a/.github/workflows/artifacts-and-rc.yml
+++ b/.github/workflows/artifacts-and-rc.yml
@@ -29,7 +29,6 @@ on:
       - completed
   workflow_dispatch:
 
-
 env:
   BASH_ENV: "~/.bashrc"
   NVM_VERSION: 0.39.3
@@ -370,7 +369,14 @@ jobs:
       - create-release-candidate
 
     steps:
-      - uses: jmg-duarte/discord-workflow-status@5a826a3e649f9d1157507494d35811ec2f84380c
+      - uses: jmg-duarte/discord-workflow-status@83dc78bf9ece4963250e5b73da83c06638c7a3bf
         with:
+          # GitHub actions does not allow secrets to be used in `if` clauses
+          # hence, instead of using an env variable, checking in the `if` and then
+          # using the env variable in parameters, I've updated the discord action to be
+          # "strict" about missing required variables, so they can be used in forks
+          # For more information on the env approach, see the following:
+          # https://stackoverflow.com/a/72926257
+          strict: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/artifacts-and-rc.yml
+++ b/.github/workflows/artifacts-and-rc.yml
@@ -371,12 +371,6 @@ jobs:
     steps:
       - uses: jmg-duarte/discord-workflow-status@0c3c34d89f51c8ff5d8dd9662b8a850579fb00fb
         with:
-          # GitHub actions does not allow secrets to be used in `if` clauses
-          # hence, instead of using an env variable, checking in the `if` and then
-          # using the env variable in parameters, I've updated the discord action to be
-          # "strict" about missing required variables, so they can be used in forks
-          # For more information on the env approach, see the following:
-          # https://stackoverflow.com/a/72926257
           strict: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,7 @@ jobs:
       - build
 
     steps:
-      - uses: jmg-duarte/discord-workflow-status@83dc78bf9ece4963250e5b73da83c06638c7a3bf
+      - uses: jmg-duarte/discord-workflow-status@0c3c34d89f51c8ff5d8dd9662b8a850579fb00fb
         with:
           # GitHub actions does not allow secrets to be used in `if` clauses
           # hence, instead of using an env variable, checking in the `if` and then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,12 +87,6 @@ jobs:
     steps:
       - uses: jmg-duarte/discord-workflow-status@0c3c34d89f51c8ff5d8dd9662b8a850579fb00fb
         with:
-          # GitHub actions does not allow secrets to be used in `if` clauses
-          # hence, instead of using an env variable, checking in the `if` and then
-          # using the env variable in parameters, I've updated the discord action to be
-          # "strict" about missing required variables, so they can be used in forks
-          # For more information on the env approach, see the following:
-          # https://stackoverflow.com/a/72926257
           strict: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - master
       - release/*
     paths-ignore:
-      - 'github/**'
+      - "github/**"
   workflow_dispatch:
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       NETLIFY_ACCESS_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
-      AZ_STORAGE_CONNECTION_STRING:  ${{ secrets.AZ_STORAGE_CONNECTION_STRING }}
+      AZ_STORAGE_CONNECTION_STRING: ${{ secrets.AZ_STORAGE_CONNECTION_STRING }}
       AZ_STORAGE_SAS_TOKEN: ${{ secrets.AZ_STORAGE_SAS_TOKEN }}
 
     defaults:
@@ -85,7 +85,14 @@ jobs:
       - build
 
     steps:
-      - uses: jmg-duarte/discord-workflow-status@5a826a3e649f9d1157507494d35811ec2f84380c
+      - uses: jmg-duarte/discord-workflow-status@83dc78bf9ece4963250e5b73da83c06638c7a3bf
         with:
+          # GitHub actions does not allow secrets to be used in `if` clauses
+          # hence, instead of using an env variable, checking in the `if` and then
+          # using the env variable in parameters, I've updated the discord action to be
+          # "strict" about missing required variables, so they can be used in forks
+          # For more information on the env approach, see the following:
+          # https://stackoverflow.com/a/72926257
+          strict: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -105,7 +105,14 @@ jobs:
       - validate-docs
 
     steps:
-      - uses: jmg-duarte/discord-workflow-status@5a826a3e649f9d1157507494d35811ec2f84380c
+      - uses: jmg-duarte/discord-workflow-status@83dc78bf9ece4963250e5b73da83c06638c7a3bf
         with:
+          # GitHub actions does not allow secrets to be used in `if` clauses
+          # hence, instead of using an env variable, checking in the `if` and then
+          # using the env variable in parameters, I've updated the discord action to be
+          # "strict" about missing required variables, so they can be used in forks
+          # For more information on the env approach, see the following:
+          # https://stackoverflow.com/a/72926257
+          strict: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -105,7 +105,7 @@ jobs:
       - validate-docs
 
     steps:
-      - uses: jmg-duarte/discord-workflow-status@83dc78bf9ece4963250e5b73da83c06638c7a3bf
+      - uses: jmg-duarte/discord-workflow-status@0c3c34d89f51c8ff5d8dd9662b8a850579fb00fb
         with:
           # GitHub actions does not allow secrets to be used in `if` clauses
           # hence, instead of using an env variable, checking in the `if` and then

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -107,12 +107,6 @@ jobs:
     steps:
       - uses: jmg-duarte/discord-workflow-status@0c3c34d89f51c8ff5d8dd9662b8a850579fb00fb
         with:
-          # GitHub actions does not allow secrets to be used in `if` clauses
-          # hence, instead of using an env variable, checking in the `if` and then
-          # using the env variable in parameters, I've updated the discord action to be
-          # "strict" about missing required variables, so they can be used in forks
-          # For more information on the env approach, see the following:
-          # https://stackoverflow.com/a/72926257
           strict: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
GitHub actions does not allow secrets to be used in `if` clauses, hence, instead of:
- using an env variable
- checking it in the `if`
- then using the env variable in parameters

I've updated the discord action to be "strict" about missing required variables, so they can be used in forks.

For more information on the env approach, see the following: https://stackoverflow.com/a/72926257