### PR TITLE
add parsing of EVENT/WORKFLOW/MACHINE

### DIFF
--- a/js/sdk/src/v2/blobSnapshotStore.ts
+++ b/js/sdk/src/v2/blobSnapshotStore.ts
@@ -242,7 +242,7 @@ export class BlobSnapshotStore implements SnapshotStore {
     if (lt(this.currentActyxVersion(), '2.12.0')) return
     try {
       const headers = mkHeaders(this.currentToken())
-      await fetch(`${this.api}/${ENDPOINT}/-/@pond/snap`)
+      await fetch(`${this.api}/${ENDPOINT}/-/@pond/snap`, { method: 'DELETE', headers })
     } catch (e) {
       log.http.error('invalidateAllSnapshots', e)
     }

--- a/rust/actyx/ax-aql/Cargo.toml
+++ b/rust/actyx/ax-aql/Cargo.toml
@@ -28,4 +28,5 @@ tracing = "0.1.40"
 unicode-normalization = "0.1.22"
 
 [dev-dependencies]
+ax_types = { version = "0.1.0", path = "../ax-types", features = ["arb"] }
 quickcheck = "1.0.3"

--- a/rust/actyx/ax-aql/src/language/aql.pest
+++ b/rust/actyx/ax-aql/src/language/aql.pest
@@ -1,4 +1,4 @@
-main_query = { SOI ~ pragma* ~ features? ~ query ~ EOI }
+main_query = { SOI ~ pragma* ~ event* ~ features? ~ query ~ EOI }
 main_tag_expr = { SOI ~ tag_expr ~ EOI }
 main_simple_expr = { SOI ~ simple_expr ~ EOI }
 main_ident = @{ SOI ~ ident ~ EOI }
@@ -7,10 +7,54 @@ main_timestamp = @{ SOI ~ isodate ~ EOI }
 
 // pragmas
 pragma = ${ "PRAGMA" ~ WHITE_SPACE+ ~ feature_word ~ ( !NEWLINE ~ WHITE_SPACE )* ~ ( pragma_multi | pragma_single ) }
-pragma_multi = _{ NEWLINE ~ pragma_multi_text ~ NEWLINE ~ "ENDPRAGMA" ~ NEWLINE }
-pragma_multi_text = ${ ( !( NEWLINE ~ "ENDPRAGMA" ~ NEWLINE ) ~ ANY )* }
+pragma_multi = _{ NEWLINE ~ pragma_multi_text ~ NEWLINE ~ pragma_end ~ NEWLINE }
+pragma_multi_text = ${ ( !( NEWLINE ~ pragma_end ~ NEWLINE ) ~ ANY )* }
+pragma_end = { "ENDPRAGMA" }
 pragma_single = _{ ":=" ~ ( !NEWLINE ~ WHITE_SPACE )* ~ pragma_single_text ~ NEWLINE }
 pragma_single_text = ${ ( !NEWLINE ~ ANY )* }
+
+features = { "FEATURES(" ~ feature_word* ~ ")" }
+feature_word = @{ ( ASCII_ALPHANUMERIC | "ø" )+ }
+
+// types
+type = { type_atom ~ type_post* ~ ( type_infix ~ type_atom ~ type_post* )* }
+type_null = { "NULL" }
+type_bool = { "BOOLEAN" }
+type_number = { "NUMBER" }
+type_timestamp = { "TIMESTAMP" }
+type_string = { "STRING" }
+type_universal = { "UNIVERSAL" }
+type_tuple = { brackl ~ type ~ ( comma ~ type )* ~ brackr }
+type_record = { curlyl ~ ( ( natural | ident | nonempty_string ) ~ colon ~ type ~ comma? )+ ~ curlyr }
+type_paren = { parenl ~ type ~ parenr }
+type_atom = _{ type_null | type_bool | bool | type_number | natural | type_timestamp | type_string | string
+  | type_tuple | type_record | type_paren | type_universal }
+type_array = { "[]" }
+type_dict = { "{}" }
+type_post = _{ type_array | type_dict }
+type_union = { "|" }
+type_intersection = { "&" }
+type_infix = _{ type_union | type_intersection }
+
+// events
+event = { "EVENT" ~ ident ~ event_type ~ tagged? }
+event_type = { type_record } // needed for parser code structure
+tagged = { "TAGGED" ~ tag ~ ( comma ~ tag )* }
+
+// workflows
+workflow = { "WORKFLOW" ~ ident ~ parenl ~ wf_arg ~ ( comma ~ wf_arg )* ~ parenr ~ wf_scope }
+wf_arg = _{ ( role | unique ) ~ ident }
+wf_scope = _{ curlyl ~ wf_step+ ~ curlyr }
+wf_step = _{ wf_event | wf_retry | wf_timeout | wf_parallel | wf_call | wf_compensate | wf_choice }
+wf_event = { ( ident ~ colon )? ~ ( fail | return )? ~ ident ~ at ~ ident ~ wf_binder* }
+wf_binder = { curlyl ~ ident ~ colon ~ ident ~ arrowl ~ ( SELF | simple_expr ) ~ curlyr }
+wf_retry = { retry ~ wf_scope }
+wf_timeout = { timeout ~ duration ~ wf_scope ~ wf_event }
+wf_parallel = { parallel ~ natural? ~ wf_scope }
+wf_call = { match ~ ident ~ parenl ~ ident ~ ( comma ~ ident )* ~ parenr ~ curlyl ~ wf_match* ~ curlyr }
+wf_match = { case ~ ( ident | star ) ~ dblarrowr ~ wf_step+ }
+wf_compensate = { compensate ~ wf_scope ~ with ~ wf_scope }
+wf_choice = { choice ~ curlyl ~ ( case ~ wf_step+ )+ ~ curlyr }
 
 // queries
 query = { "FROM" ~ ( tag_expr ~ query_order? | array ) ~ query_op* ~ "END"? }
@@ -19,11 +63,10 @@ order = { "ASC" | "DESC" | "STREAM" }
 query_op = _{ filter | select | aggregate | limit | binding }
 filter = { "FILTER" ~ simple_expr }
 select = { "SELECT" ~ spread? ~ simple_expr ~ ( "," ~ spread? ~ simple_expr )* }
+machine = { "MACHINE" ~ ident ~ role ~ ident ~ id ~ nonempty_string }
 aggregate = { "AGGREGATE" ~ simple_expr }
 limit = { "LIMIT" ~ positive }
 binding = { "LET" ~ ident ~ ":=" ~ simple_expr }
-features = { "FEATURES(" ~ feature_word* ~ ")" }
-feature_word = @{ ( ASCII_ALPHANUMERIC | "ø" )+ }
 
 // strings
 single_quoted = @{ "'" ~ ( !"'" ~ ANY | "''" )+ ~ "'" }
@@ -71,6 +114,7 @@ nanosecond = { ( '0'..'9'{9} ) }
 isodate = ${ year ~ "-" ~ month ~ "-" ~ day ~ ("T" ~ hour ~ ":" ~ minute ~ (":" ~ second ~ ("." ~ (nanosecond|microsecond|millisecond))?)?)? ~ ( "Z" | sign ~ hour ~ ":" ~ minute ) }
 
 // some duration ago
+duration = ${ natural ~ duration_unit ~ ( WHITE_SPACE* ~ natural ~ duration_unit )* }
 duration_ago = ${ natural ~ duration_unit ~ WHITE_SPACE ~ "ago" }
 duration_unit = { "Y" | "M" | "W" | "D" | "h" | "m" | "s" }
 
@@ -134,6 +178,37 @@ eq = { "=" }
 ne = { "!=" | "≠" }
 alternative = { "??" }
 spread = { "..." }
+
+// syntax elements
+at = { "@" }
+star = { "*" }
+colon = { ":" }
+comma = { "," }
+parenl = { "(" }
+parenr = { ")" }
+curlyl = { "{" }
+curlyr = { "}" }
+brackl = { "[" }
+brackr = { "]" }
+arrowl = { "<-" | "←" }
+arrowr = { "->" | "→" }
+dblarrowl = { "<=" | "⇐" | "⟸" }
+dblarrowr = { "=>" | "⇒" | "⟹" }
+
+case = { "CASE" }
+choice = { "CHOICE" }
+compensate = { "COMPENSATE" }
+fail = { "FAIL" }
+id = { "ID" }
+match = { "MATCH" }
+parallel = { "PARALLEL" }
+retry = { "RETRY" }
+return = { "RETURN" }
+role = { "ROLE" }
+SELF = { "SELF" }
+timeout = { "TIMEOUT" }
+unique = { "UNIQUE" }
+with = { "WITH" }
 
 WHITESPACE = _{ WHITE_SPACE }
 COMMENT = _{ "--" ~ ( !("\n"|"\r") ~ ANY )* }

--- a/rust/actyx/ax-aql/src/language/aql.pest
+++ b/rust/actyx/ax-aql/src/language/aql.pest
@@ -1,4 +1,4 @@
-main_query = { SOI ~ pragma* ~ event* ~ features? ~ query ~ EOI }
+main_query = { SOI ~ pragma* ~ event* ~ workflow* ~ features? ~ query ~ EOI }
 main_tag_expr = { SOI ~ tag_expr ~ EOI }
 main_simple_expr = { SOI ~ simple_expr ~ EOI }
 main_ident = @{ SOI ~ ident ~ EOI }
@@ -43,24 +43,26 @@ tagged = { "TAGGED" ~ tag ~ ( comma ~ tag )* }
 
 // workflows
 workflow = { "WORKFLOW" ~ ident ~ parenl ~ wf_arg ~ ( comma ~ wf_arg )* ~ parenr ~ wf_scope }
-wf_arg = _{ ( role | unique ) ~ ident }
-wf_scope = _{ curlyl ~ wf_step+ ~ curlyr }
+wf_arg = { ( role | unique ) ~ ident }
+wf_scope = { curlyl ~ wf_step+ ~ curlyr }
 wf_step = _{ wf_event | wf_retry | wf_timeout | wf_parallel | wf_call | wf_compensate | wf_choice }
-wf_event = { ( ident ~ colon )? ~ ( fail | return )? ~ ident ~ at ~ ident ~ wf_binder* }
-wf_binder = { curlyl ~ ident ~ colon ~ ident ~ arrowl ~ ( SELF | simple_expr ) ~ curlyr }
+wf_event = { ( wf_state ~ colon )? ~ ( fail | return )? ~ ident ~ at ~ ident ~ wf_binder* }
+wf_state = { ident }
+wf_binder = { curlyl ~ ident ~ colon ~ ident ~ arrowl ~ simple_expr ~ curlyr }
 wf_retry = { retry ~ wf_scope }
 wf_timeout = { timeout ~ duration ~ wf_scope ~ wf_event }
-wf_parallel = { parallel ~ natural? ~ wf_scope }
+wf_parallel = { parallel ~ natural? ~ wf_cases }
 wf_call = { match ~ ident ~ parenl ~ ident ~ ( comma ~ ident )* ~ parenr ~ curlyl ~ wf_match* ~ curlyr }
 wf_match = { case ~ ( ident | star ) ~ dblarrowr ~ wf_step+ }
 wf_compensate = { compensate ~ wf_scope ~ with ~ wf_scope }
-wf_choice = { choice ~ curlyl ~ ( case ~ wf_step+ )+ ~ curlyr }
+wf_choice = { choice ~ wf_cases }
+wf_cases = _{ curlyl ~ ( case ~ wf_step+ )+ ~ curlyr }
 
 // queries
 query = { "FROM" ~ ( tag_expr ~ query_order? | array ) ~ query_op* ~ "END"? }
 query_order = { "ORDER" ~ order }
 order = { "ASC" | "DESC" | "STREAM" }
-query_op = _{ filter | select | aggregate | limit | binding }
+query_op = _{ filter | select | aggregate | limit | binding | machine }
 filter = { "FILTER" ~ simple_expr }
 select = { "SELECT" ~ spread? ~ simple_expr ~ ( "," ~ spread? ~ simple_expr )* }
 machine = { "MACHINE" ~ ident ~ role ~ ident ~ id ~ nonempty_string }
@@ -116,7 +118,7 @@ isodate = ${ year ~ "-" ~ month ~ "-" ~ day ~ ("T" ~ hour ~ ":" ~ minute ~ (":" 
 // some duration ago
 duration = ${ natural ~ duration_unit ~ ( WHITE_SPACE* ~ natural ~ duration_unit )* }
 duration_ago = ${ natural ~ duration_unit ~ WHITE_SPACE ~ "ago" }
-duration_unit = { "Y" | "M" | "W" | "D" | "h" | "m" | "s" }
+duration_unit = { "Y" | "M" | "W" | "D" | "h" | "m" | "s" | "u" }
 
 // metadata
 meta_key = { "KEY(" ~ ( ident | event_key ) ~ ")" }

--- a/rust/actyx/ax-aql/src/language/mod.rs
+++ b/rust/actyx/ax-aql/src/language/mod.rs
@@ -64,7 +64,7 @@ pub struct Query<'a> {
 mod query_impl;
 mod rewrite_impl;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct Ident(NonEmptyString);
 
 impl Display for Ident {

--- a/rust/actyx/ax-aql/src/language/mod.rs
+++ b/rust/actyx/ax-aql/src/language/mod.rs
@@ -863,19 +863,26 @@ mod for_tests {
 
     impl Arbitrary for TypeAtom {
         fn arbitrary(g: &mut Gen) -> Self {
-            arb!(TypeAtom: g => Bool Number String, Tuple Record,, Null Timestamp Universal)
+            arb!(TypeAtom: g => Bool Number String,,, Null Timestamp Universal)
         }
         fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-            shrink!(TypeAtom: self => Bool Number String, Tuple(x,) Record(x,), Null Timestamp Universal)
+            shrink!(TypeAtom: self => Bool Number String,, Null Timestamp Universal)
         }
     }
 
     impl Arbitrary for Type {
         fn arbitrary(g: &mut Gen) -> Self {
-            arb!(Type: g => Atom, Union Intersection Array Dict,,)
+            arb!(Type: g => Atom, Union Intersection Array Dict Tuple Record,,)
         }
         fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-            shrink!(Type: self => Atom, Union(x, x.0.clone(), x.1.clone()) Intersection(x, x.0.clone(), x.1.clone()) Array(x,(**x).clone()) Dict(x,(**x).clone()),)
+            shrink!(Type: self => Atom,
+                Union(x, x.0.clone(), x.1.clone())
+                Intersection(x, x.0.clone(), x.1.clone())
+                Array(x,(**x).clone())
+                Dict(x,(**x).clone())
+                Tuple(x,)
+                Record(x,)
+            ,)
         }
     }
 
@@ -1160,9 +1167,8 @@ mod for_tests {
                     .into_iter()
                     .map(|label| {
                         let tags = Vec::<SingleTag>::arbitrary(g);
-                        let t = Type::Atom(TypeAtom::Record(
-                            NonEmptyVec::<Label>::arbitrary(g).map(|l| (l.clone(), Type::arbitrary(g))),
-                        ));
+                        let t =
+                            Type::Record(NonEmptyVec::<Label>::arbitrary(g).map(|l| (l.clone(), Type::arbitrary(g))));
                         (label, (t, tags))
                     })
                     .collect()

--- a/rust/actyx/ax-aql/src/language/non_empty.rs
+++ b/rust/actyx/ax-aql/src/language/non_empty.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NonEmptyVec<T>(Arc<[T]>);
 
 impl<T> NonEmptyVec<T> {
@@ -66,7 +66,7 @@ impl<T: quickcheck::Arbitrary + Clone + 'static> quickcheck::Arbitrary for NonEm
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NonEmptyString(String);
 
 #[derive(Debug, Clone)]
@@ -113,6 +113,12 @@ impl Deref for NonEmptyString {
 impl DerefMut for NonEmptyString {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl AsRef<str> for NonEmptyString {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/rust/actyx/ax-aql/src/language/non_empty.rs
+++ b/rust/actyx/ax-aql/src/language/non_empty.rs
@@ -1,5 +1,9 @@
 #![allow(dead_code)]
-use std::{convert::TryFrom, ops::Deref, sync::Arc};
+use std::{
+    convert::TryFrom,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NonEmptyVec<T>(Arc<[T]>);
@@ -99,14 +103,23 @@ impl TryFrom<&str> for NonEmptyString {
 }
 
 impl Deref for NonEmptyString {
-    type Target = str;
+    type Target = String;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_str()
+        &self.0
+    }
+}
+
+impl DerefMut for NonEmptyString {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
 impl NonEmptyString {
+    pub fn new(c: char) -> Self {
+        Self(c.to_string())
+    }
     pub fn into_inner(self) -> String {
         self.0
     }

--- a/rust/actyx/ax-aql/src/language/parse_utils.rs
+++ b/rust/actyx/ax-aql/src/language/parse_utils.rs
@@ -1,8 +1,16 @@
 use super::parser::{NoVal, Rule};
 use crate::language::non_empty::NonEmptyString;
 use anyhow::Result;
-use pest::iterators::{Pair, Pairs};
-use std::{convert::TryInto, fmt::Debug, str::FromStr};
+use pest::{
+    error::ErrorVariant,
+    iterators::{Pair, Pairs},
+};
+use std::{
+    convert::TryInto,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 pub type Ps<'a> = Pairs<'a, Rule>;
 pub type P<'a> = Pair<'a, Rule>;
@@ -107,5 +115,79 @@ impl<'a> Ext<'a> for P<'a> {
         T::Err: Send + Sync + 'static,
     {
         Ok(self.as_str().parse::<T>()?)
+    }
+}
+
+pub trait Spanned {
+    type Ret;
+    fn spanned(self, span: pest::Span) -> Self::Ret;
+}
+
+impl<T, E: ToString> Spanned for Result<T, E> {
+    type Ret = Result<T, pest::error::Error<Rule>>;
+    fn spanned(self, span: pest::Span) -> Self::Ret {
+        self.map_err(|e| {
+            let e = ErrorVariant::CustomError { message: e.to_string() };
+            pest::error::Error::new_from_span(e, span)
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq)]
+pub struct Span<'a, T> {
+    span: pest::Span<'a>,
+    value: T,
+}
+
+impl<'a, T: PartialEq> PartialEq for Span<'a, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<'a, T: Ord> Ord for Span<'a, T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<'a, T: Ord> PartialOrd for Span<'a, T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl<'a, T> Span<'a, T> {
+    pub fn new(span: pest::Span<'a>, value: T) -> Self {
+        Self { span, value }
+    }
+
+    pub fn make(p: P<'a>, f: impl FnOnce(P<'a>) -> Result<T>) -> Result<Self> {
+        Ok(Self::new(p.as_span(), f(p)?))
+    }
+
+    pub fn err(&self, msg: impl Into<String>) -> Result<(), pest::error::Error<Rule>> {
+        Err(pest::error::Error::new_from_span(
+            pest::error::ErrorVariant::CustomError { message: msg.into() },
+            self.span,
+        ))
+    }
+
+    pub fn span(&self) -> pest::Span<'a> {
+        self.span
+    }
+}
+
+impl<'a, T> Deref for Span<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<'a, T> DerefMut for Span<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
     }
 }

--- a/rust/actyx/ax-aql/src/language/parse_utils.rs
+++ b/rust/actyx/ax-aql/src/language/parse_utils.rs
@@ -1,13 +1,9 @@
-use super::{NoVal, Rule};
+use super::parser::{NoVal, Rule};
 use crate::language::non_empty::NonEmptyString;
 use anyhow::Result;
-use pest::{
-    error::Error,
-    iterators::{Pair, Pairs},
-};
+use pest::iterators::{Pair, Pairs};
 use std::{convert::TryInto, fmt::Debug, str::FromStr};
 
-pub type R<T> = std::result::Result<T, Error<Rule>>;
 pub type Ps<'a> = Pairs<'a, Rule>;
 pub type P<'a> = Pair<'a, Rule>;
 

--- a/rust/actyx/ax-aql/src/language/parse_utils.rs
+++ b/rust/actyx/ax-aql/src/language/parse_utils.rs
@@ -153,7 +153,7 @@ impl<'a, T: Ord> Ord for Span<'a, T> {
 
 impl<'a, T: Ord> PartialOrd for Span<'a, T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 
@@ -166,6 +166,7 @@ impl<'a, T> Span<'a, T> {
         Ok(Self::new(p.as_span(), f(p)?))
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn err(&self, msg: impl Into<String>) -> Result<(), pest::error::Error<Rule>> {
         Err(pest::error::Error::new_from_span(
             pest::error::ErrorVariant::CustomError { message: msg.into() },

--- a/rust/actyx/ax-aql/src/language/parser.rs
+++ b/rust/actyx/ax-aql/src/language/parser.rs
@@ -8,9 +8,9 @@ use std::{
     sync::Arc,
 };
 
-use super::parse_utils::*;
 use super::{
     non_empty::{NonEmptyString, NonEmptyVec},
+    parse_utils::*,
     types::r_type,
     workflow::r_workflow,
     AggrOp, Arr, FuncCall, Ident, Ind, Index, Num, Obj, Operation, Query, SimpleExpr, Source, SpreadExpr, TagAtom,

--- a/rust/actyx/ax-aql/src/language/query_impl.rs
+++ b/rust/actyx/ax-aql/src/language/query_impl.rs
@@ -10,11 +10,13 @@ impl<'a> Query<'a> {
         let features = self.features;
         let source = self.source;
         let ops = self.ops;
+        let events = self.events;
         Query {
             pragmas: Vec::new(),
             features,
             source,
             ops,
+            events,
         }
     }
 
@@ -51,6 +53,7 @@ impl<'de> Deserialize<'de> for StaticQuery {
             features: q.features,
             source: q.source,
             ops: q.ops,
+            events: q.events,
         }))
     }
 }

--- a/rust/actyx/ax-aql/src/language/query_impl.rs
+++ b/rust/actyx/ax-aql/src/language/query_impl.rs
@@ -100,9 +100,13 @@ impl<'a> std::fmt::Display for Query<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::HashSet;
 
     use crate::{Label, Query};
+
+    fn slice_to_labels(s: &[&str]) -> HashSet<Label> {
+        s.iter().map(|s| Label::try_from(*s).unwrap()).collect()
+    }
 
     #[test]
     fn test_used_events_empty() {
@@ -114,8 +118,8 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(map.is_empty());
+        let event_types = query.get_used_event_types().collect::<HashSet<_>>();
+        assert!(event_types.is_empty());
     }
 
     #[test]
@@ -134,13 +138,9 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start"]));
     }
 
     #[test]
@@ -161,13 +161,9 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start"]));
     }
 
     #[test]
@@ -189,13 +185,9 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("timeout", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start", "timeout"]));
     }
 
     #[test]
@@ -216,13 +208,9 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start"]));
     }
 
     #[test]
@@ -247,13 +235,9 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start"]));
     }
 
     #[test]
@@ -278,13 +262,9 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start"]));
     }
 
     #[test]
@@ -307,13 +287,9 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("pause", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start", "pause"]));
     }
 
     #[test]
@@ -349,12 +325,8 @@ mod tests {
         )
         .expect("should be a valid query");
 
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        assert!([("start", true), ("pause", true), ("timeout", true), ("done", false)]
-            .into_iter()
-            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
-            .all(|(label, exists)| map.contains_key(&label) == exists));
+        let labels = query.get_used_event_types().map(|t| t.0).collect::<HashSet<_>>();
+        assert!(!labels.is_empty());
+        assert_eq!(labels, slice_to_labels(&["start", "pause", "timeout"]));
     }
 }

--- a/rust/actyx/ax-aql/src/language/query_impl.rs
+++ b/rust/actyx/ax-aql/src/language/query_impl.rs
@@ -1,7 +1,7 @@
 use super::workflow::Workflow;
 use crate::{
     language::{parser::query_from_str, render::render_query, Query, StaticQuery},
-    Ident, Type,
+    Ident, Label, Type,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
@@ -45,7 +45,7 @@ impl<'a> Query<'a> {
         (q, features, pragmas, self.workflows)
     }
 
-    pub fn get_used_event_types(&'a self) -> impl Iterator<Item = Type> + 'a {
+    pub fn get_used_event_types(&'a self) -> impl Iterator<Item = (Label, Type)> + 'a {
         self.workflows
             .iter()
             .flat_map(|(_, workflow)| workflow.steps.iter().map(|step| step.get_events()))
@@ -53,8 +53,7 @@ impl<'a> Query<'a> {
             // if we just took the idents earlier we could probably replace the vecs in get_events with iterators
             .map(|events| events.deref().clone())
             .into_iter()
-            .filter_map(|ident| self.events.get(&ident).map(|(ty, _)| ty))
-            .cloned()
+            .filter_map(|ident| self.events.get(&ident).map(|(ty, _)| (Label::from(ident), ty.clone())))
     }
 }
 
@@ -97,5 +96,327 @@ impl<'a> Serialize for Query<'a> {
 impl<'a> std::fmt::Display for Query<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         render_query(f, self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{Label, Query};
+
+    #[test]
+    fn test_used_events_empty() {
+        let query = Query::parse(
+            "
+            EVENT start { _: NULL }
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_used_events_event_step() {
+        let query = Query::parse(
+            "
+            EVENT start { _: NULL }
+            EVENT done  { _: NULL }
+
+            WORKFLOW w (UNIQUE a) {
+                start @ a
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_retry_step() {
+        let query = Query::parse(
+            "
+            EVENT start { _: NULL }
+            EVENT done  { _: NULL }
+
+            WORKFLOW w (UNIQUE a) {
+                RETRY {
+                    start @ a
+                }
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_timeout_step() {
+        let query = Query::parse(
+            "
+            EVENT start   { _: NULL }
+            EVENT timeout { _: NULL }
+            EVENT done    { _: NULL }
+
+            WORKFLOW w (UNIQUE a) {
+                TIMEOUT 1m {
+                    start @ a
+                } RETURN timeout @ a
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let timeout_label = Label::try_from("timeout").expect("should be a valid label");
+        assert!(map.get(&timeout_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_parallel_step() {
+        let query = Query::parse(
+            "
+            EVENT start { _: NULL }
+            EVENT done  { _: NULL }
+
+            WORKFLOW w (UNIQUE a) {
+                PARALLEL 2 {
+                    CASE start @ a
+                }
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_call_step() {
+        let query = Query::parse(
+            "
+            EVENT start { _: NULL }
+            EVENT done  { _: NULL }
+
+            WORKFLOW callee (UNIQUE a) {
+                start @ a
+            }
+
+            WORKFLOW caller (UNIQUE a) {
+                MATCH callee (a) {
+                    CASE * => start @ a
+                }
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_compensate_step() {
+        let query = Query::parse(
+            "
+            EVENT start { _: NULL }
+            EVENT done  { _: NULL }
+
+            WORKFLOW caller (UNIQUE a) {
+                COMPENSATE {
+                    start @ a
+                } WITH {
+                    -- this workflow doesn't make sense
+                    -- but we're not testing semantics
+                    start @ a
+                }
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_choice_step() {
+        let query = Query::parse(
+            "
+            EVENT start { _: NULL }
+            EVENT pause { _: NULL }
+            EVENT done  { _: NULL }
+
+            WORKFLOW caller (UNIQUE a) {
+                CHOICE {
+                    CASE start @ a
+                    CASE pause @ a
+                }
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let pause_label = Label::try_from("pause").expect("should be a valid label");
+        assert!(map.get(&pause_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_retry_timeout_choice_steps() {
+        let query = Query::parse(
+            "
+            EVENT start   { _: NULL }
+            EVENT pause   { _: NULL }
+            EVENT timeout { _: NULL }
+            EVENT done    { _: NULL }
+
+            WORKFLOW caller (UNIQUE a) {
+                RETRY {
+                    TIMEOUT 1m {
+                        CHOICE {
+                            CASE start @ a
+                            CASE pause @ a
+                        }
+                    } RETURN timeout @ a
+                }
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let pause_label = Label::try_from("pause").expect("should be a valid label");
+        assert!(map.get(&pause_label).is_some());
+
+        let timeout_label = Label::try_from("timeout").expect("should be a valid label");
+        assert!(map.get(&timeout_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
+    }
+
+    #[test]
+    fn test_used_events_retry_timeout_choice_match_parallel_steps() {
+        let query = Query::parse(
+            "
+            EVENT start   { _: NULL }
+            EVENT pause   { _: NULL }
+            EVENT timeout { _: NULL }
+            EVENT done    { _: NULL }
+
+            WORKFLOW callee (UNIQUE a) {
+                PARALLEL 1 {
+                    CASE start @ a
+                }
+            }
+
+            WORKFLOW caller (UNIQUE a) {
+                RETRY {
+                    TIMEOUT 1m {
+                        CHOICE {
+                            CASE start @ a
+                        }
+                    } RETURN timeout @ a
+                }
+                MATCH callee(a) {
+                    CASE * => pause @ a
+                }
+            }
+
+            FROM allEvents
+            ",
+        )
+        .expect("should be a valid query");
+
+        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
+        assert!(!map.is_empty());
+
+        let start_label = Label::try_from("start").expect("should be a valid label");
+        assert!(map.get(&start_label).is_some());
+
+        let pause_label = Label::try_from("pause").expect("should be a valid label");
+        assert!(map.get(&pause_label).is_some());
+
+        let timeout_label = Label::try_from("timeout").expect("should be a valid label");
+        assert!(map.get(&timeout_label).is_some());
+
+        let done_label = Label::try_from("done").expect("should be a valid label");
+        assert!(map.get(&done_label).is_none());
     }
 }

--- a/rust/actyx/ax-aql/src/language/query_impl.rs
+++ b/rust/actyx/ax-aql/src/language/query_impl.rs
@@ -331,47 +331,6 @@ mod tests {
     }
 
     #[test]
-    fn test_used_events_retry_timeout_choice_steps() {
-        let query = Query::parse(
-            "
-            EVENT start   { _: NULL }
-            EVENT pause   { _: NULL }
-            EVENT timeout { _: NULL }
-            EVENT done    { _: NULL }
-
-            WORKFLOW caller (UNIQUE a) {
-                RETRY {
-                    TIMEOUT 1m {
-                        CHOICE {
-                            CASE start @ a
-                            CASE pause @ a
-                        }
-                    } RETURN timeout @ a
-                }
-            }
-
-            FROM allEvents
-            ",
-        )
-        .expect("should be a valid query");
-
-        let map = query.get_used_event_types().collect::<HashMap<_, _>>();
-        assert!(!map.is_empty());
-
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let pause_label = Label::try_from("pause").expect("should be a valid label");
-        assert!(map.get(&pause_label).is_some());
-
-        let timeout_label = Label::try_from("timeout").expect("should be a valid label");
-        assert!(map.get(&timeout_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
-    }
-
-    #[test]
     fn test_used_events_retry_timeout_choice_match_parallel_steps() {
         let query = Query::parse(
             "

--- a/rust/actyx/ax-aql/src/language/query_impl.rs
+++ b/rust/actyx/ax-aql/src/language/query_impl.rs
@@ -52,7 +52,6 @@ impl<'a> Query<'a> {
             .flatten()
             // if we just took the idents earlier we could probably replace the vecs in get_events with iterators
             .map(|events| events.deref().clone())
-            .into_iter()
             .filter_map(|ident| self.events.get(&ident).map(|(ty, _)| (Label::from(ident), ty.clone())))
     }
 }

--- a/rust/actyx/ax-aql/src/language/query_impl.rs
+++ b/rust/actyx/ax-aql/src/language/query_impl.rs
@@ -137,11 +137,10 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 
     #[test]
@@ -165,11 +164,10 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 
     #[test]
@@ -194,14 +192,10 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let timeout_label = Label::try_from("timeout").expect("should be a valid label");
-        assert!(map.get(&timeout_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("timeout", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 
     #[test]
@@ -225,11 +219,10 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 
     #[test]
@@ -257,11 +250,10 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 
     #[test]
@@ -289,11 +281,10 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 
     #[test]
@@ -319,14 +310,10 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let pause_label = Label::try_from("pause").expect("should be a valid label");
-        assert!(map.get(&pause_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("pause", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 
     #[test]
@@ -365,16 +352,9 @@ mod tests {
         let map = query.get_used_event_types().collect::<HashMap<_, _>>();
         assert!(!map.is_empty());
 
-        let start_label = Label::try_from("start").expect("should be a valid label");
-        assert!(map.get(&start_label).is_some());
-
-        let pause_label = Label::try_from("pause").expect("should be a valid label");
-        assert!(map.get(&pause_label).is_some());
-
-        let timeout_label = Label::try_from("timeout").expect("should be a valid label");
-        assert!(map.get(&timeout_label).is_some());
-
-        let done_label = Label::try_from("done").expect("should be a valid label");
-        assert!(map.get(&done_label).is_none());
+        assert!([("start", true), ("pause", true), ("timeout", true), ("done", false)]
+            .into_iter()
+            .flat_map(|(label, exists)| Label::try_from(label).map(|label| (label, exists)))
+            .all(|(label, exists)| map.contains_key(&label) == exists));
     }
 }

--- a/rust/actyx/ax-aql/src/language/render.rs
+++ b/rust/actyx/ax-aql/src/language/render.rs
@@ -306,28 +306,6 @@ fn render_type_atom(w: &mut impl Write, a: &TypeAtom) -> Result {
         TypeAtom::Timestamp => w.write_str("TIMESTAMP"),
         TypeAtom::String(Some(s)) => render_string(w, s),
         TypeAtom::String(None) => w.write_str("STRING"),
-        TypeAtom::Tuple(ts) => {
-            w.write_char('[')?;
-            for (i, t) in ts.iter().enumerate() {
-                if i > 0 {
-                    w.write_str(", ")?;
-                }
-                render_type(w, t)?;
-            }
-            w.write_char(']')
-        }
-        TypeAtom::Record(ts) => {
-            w.write_char('{')?;
-            for (i, (l, t)) in ts.iter().enumerate() {
-                if i > 0 {
-                    w.write_str(", ")?;
-                }
-                render_label(w, l)?;
-                w.write_str(": ")?;
-                render_type(w, t)?;
-            }
-            w.write_char('}')
-        }
         TypeAtom::Universal => w.write_str("UNIVERSAL"),
     }
 }
@@ -350,12 +328,34 @@ fn render_type(w: &mut impl Write, t: &Type) -> Result {
             w.write_char(')')
         }
         Type::Array(t) => {
-            render_type(w, &t)?;
+            render_type(w, t)?;
             w.write_str("[]")
         }
         Type::Dict(t) => {
-            render_type(w, &t)?;
+            render_type(w, t)?;
             w.write_str("{}")
+        }
+        Type::Tuple(ts) => {
+            w.write_char('[')?;
+            for (i, t) in ts.iter().enumerate() {
+                if i > 0 {
+                    w.write_str(", ")?;
+                }
+                render_type(w, t)?;
+            }
+            w.write_char(']')
+        }
+        Type::Record(ts) => {
+            w.write_char('{')?;
+            for (i, (l, t)) in ts.iter().enumerate() {
+                if i > 0 {
+                    w.write_str(", ")?;
+                }
+                render_label(w, l)?;
+                w.write_str(": ")?;
+                render_type(w, t)?;
+            }
+            w.write_char('}')
         }
     }
 }

--- a/rust/actyx/ax-aql/src/language/render.rs
+++ b/rust/actyx/ax-aql/src/language/render.rs
@@ -398,7 +398,7 @@ fn render_event_step(
     mode: &EventMode,
     label: &Span<Ident>,
     participant: &Span<Ident>,
-    binders: &Vec<Span<Binding>>,
+    binders: &[Span<Binding>],
 ) -> Result {
     match mode {
         EventMode::Return => w.write_str("RETURN ")?,

--- a/rust/actyx/ax-aql/src/language/render.rs
+++ b/rust/actyx/ax-aql/src/language/render.rs
@@ -268,7 +268,107 @@ fn render_tag_atom(w: &mut impl Write, e: &TagAtom) -> Result {
     }
 }
 
+fn render_single_tag(w: &mut impl Write, e: &SingleTag) -> Result {
+    match e {
+        SingleTag::Tag(t) => render_string(w, t.as_ref()),
+        SingleTag::Interpolation(s) => render_interpolation(w, s),
+    }
+}
+
+fn render_label(w: &mut impl Write, l: &Label) -> Result {
+    match l {
+        Label::String(s) => {
+            if is_ident(s) {
+                w.write_str(s)
+            } else {
+                render_string(w, s)
+            }
+        }
+        Label::Number(n) => write!(w, "{n}"),
+    }
+}
+
+fn render_type_atom(w: &mut impl Write, a: &TypeAtom) -> Result {
+    match a {
+        TypeAtom::Null => w.write_str("NULL"),
+        TypeAtom::Bool(Some(b)) => render_bool(b, w),
+        TypeAtom::Bool(None) => w.write_str("BOOLEAN"),
+        TypeAtom::Number(Some(n)) => write!(w, "{n}"),
+        TypeAtom::Number(None) => w.write_str("NUMBER"),
+        TypeAtom::Timestamp => w.write_str("TIMESTAMP"),
+        TypeAtom::String(Some(s)) => render_string(w, s),
+        TypeAtom::String(None) => w.write_str("STRING"),
+        TypeAtom::Tuple(ts) => {
+            w.write_char('[')?;
+            for (i, t) in ts.iter().enumerate() {
+                if i > 0 {
+                    w.write_str(", ")?;
+                }
+                render_type(w, t)?;
+            }
+            w.write_char(']')
+        }
+        TypeAtom::Record(ts) => {
+            w.write_char('{')?;
+            for (i, (l, t)) in ts.iter().enumerate() {
+                if i > 0 {
+                    w.write_str(", ")?;
+                }
+                render_label(w, l)?;
+                w.write_str(": ")?;
+                render_type(w, t)?;
+            }
+            w.write_char('}')
+        }
+        TypeAtom::Universal => w.write_str("UNIVERSAL"),
+    }
+}
+
+fn render_type(w: &mut impl Write, t: &Type) -> Result {
+    match t {
+        Type::Atom(a) => render_type_atom(w, a),
+        Type::Union(u) => {
+            w.write_char('(')?;
+            render_type(w, &u.0)?;
+            w.write_str(" | ")?;
+            render_type(w, &u.1)?;
+            w.write_char(')')
+        }
+        Type::Intersection(i) => {
+            w.write_char('(')?;
+            render_type(w, &i.0)?;
+            w.write_str(" & ")?;
+            render_type(w, &i.1)?;
+            w.write_char(')')
+        }
+        Type::Array(t) => {
+            render_type(w, &t)?;
+            w.write_str("[]")
+        }
+        Type::Dict(t) => {
+            render_type(w, &t)?;
+            w.write_str("{}")
+        }
+    }
+}
+
 pub fn render_query(w: &mut impl Write, e: &Query) -> Result {
+    for (label, (t, tags)) in e.events.iter() {
+        w.write_str("EVENT ")?;
+        w.write_str(label.as_ref())?;
+        w.write_char(' ')?;
+        render_type(w, t)?;
+        if !tags.is_empty() {
+            w.write_str(" TAGGED ")?;
+            for (i, t) in tags.iter().enumerate() {
+                if i > 0 {
+                    w.write_str(", ")?;
+                }
+                render_single_tag(w, t)?;
+            }
+        }
+        w.write_str("\n")?;
+    }
     if !e.features.is_empty() {
         w.write_str("FEATURES(")?;
         for (i, f) in e.features.iter().enumerate() {

--- a/rust/actyx/ax-aql/src/language/rewrite_impl.rs
+++ b/rust/actyx/ax-aql/src/language/rewrite_impl.rs
@@ -8,6 +8,10 @@
 //! The benefit is structural sharing, i.e. minimal copying, so we need to be
 //! careful to design the API such that this goal is achieved, lest the effort
 //! be for naught.
+use self::{
+    parse_utils::Span,
+    workflow::{Binding, Workflow, WorkflowStep},
+};
 use super::*;
 
 /// Instruct Galactus how to continue
@@ -52,6 +56,11 @@ impl<'a> Query<'a> {
                 (label.clone(), (t.clone(), tags))
             })
             .collect::<BTreeMap<_, _>>();
+        let workflows = self
+            .workflows
+            .iter()
+            .map(|(name, workflow)| (name.clone(), shed(workflow.rewrite(surfer), &mut changed)))
+            .collect::<BTreeMap<_, _>>();
         emit(
             || Self {
                 pragmas: self.pragmas.clone(),
@@ -59,6 +68,130 @@ impl<'a> Query<'a> {
                 source,
                 ops,
                 events: Arc::new(events),
+                workflows: Arc::new(workflows),
+            },
+            changed,
+            self,
+        )
+    }
+}
+
+impl<'a> Workflow<'a> {
+    pub fn rewrite(&self, surfer: &mut impl Galactus) -> (Self, bool) {
+        let mut changed = false;
+        let steps = self.steps.map(|step| shed(step.rewrite(surfer), &mut changed));
+        emit(
+            || Workflow {
+                name: self.name.clone(),
+                args: self.args.clone(),
+                steps,
+            },
+            changed,
+            self,
+        )
+    }
+}
+
+impl<'a> WorkflowStep<'a> {
+    pub fn rewrite(&self, surfer: &mut impl Galactus) -> (Self, bool) {
+        match self {
+            WorkflowStep::Event {
+                state,
+                mode,
+                label,
+                participant,
+                binders,
+            } => {
+                let mut changed = false;
+                let binders = binders
+                    .iter()
+                    .map(|b| Span::new(b.span(), shed(b.rewrite(surfer), &mut changed)))
+                    .collect();
+                emit(
+                    || WorkflowStep::Event {
+                        state: state.clone(),
+                        mode: *mode,
+                        label: label.clone(),
+                        participant: participant.clone(),
+                        binders,
+                    },
+                    changed,
+                    self,
+                )
+            }
+            WorkflowStep::Retry { steps } => {
+                let mut changed = false;
+                let steps = steps.map(|step| shed(step.rewrite(surfer), &mut changed));
+                emit(|| WorkflowStep::Retry { steps }, changed, self)
+            }
+            WorkflowStep::Timeout {
+                micros,
+                steps,
+                mode,
+                label,
+                participant,
+                binders,
+            } => {
+                let mut changed = false;
+                let steps = steps.map(|step| shed(step.rewrite(surfer), &mut changed));
+                let binders = binders
+                    .iter()
+                    .map(|b| Span::new(b.span(), shed(b.rewrite(surfer), &mut changed)))
+                    .collect();
+                emit(
+                    || WorkflowStep::Timeout {
+                        micros: *micros,
+                        steps,
+                        mode: *mode,
+                        label: label.clone(),
+                        participant: participant.clone(),
+                        binders,
+                    },
+                    changed,
+                    self,
+                )
+            }
+            WorkflowStep::Parallel { count, cases } => {
+                let mut changed = false;
+                let cases = cases.map(|case| case.map(|step| shed(step.rewrite(surfer), &mut changed)));
+                emit(|| WorkflowStep::Parallel { count: *count, cases }, changed, self)
+            }
+            WorkflowStep::Call { workflow, args, cases } => {
+                let mut changed = false;
+                let cases = cases.map(|case| {
+                    (
+                        case.0.clone(),
+                        case.1.map(|step| shed(step.rewrite(surfer), &mut changed)),
+                    )
+                });
+                let workflow = workflow.clone();
+                let args = args.clone();
+                emit(|| WorkflowStep::Call { workflow, args, cases }, changed, self)
+            }
+            WorkflowStep::Compensate { body, with } => {
+                let mut changed = false;
+                let body = body.map(|step| shed(step.rewrite(surfer), &mut changed));
+                let with = with.map(|step| shed(step.rewrite(surfer), &mut changed));
+                emit(|| WorkflowStep::Compensate { body, with }, changed, self)
+            }
+            WorkflowStep::Choice { cases } => {
+                let mut changed = false;
+                let cases = cases.map(|case| case.map(|step| shed(step.rewrite(surfer), &mut changed)));
+                emit(|| WorkflowStep::Choice { cases }, changed, self)
+            }
+        }
+    }
+}
+
+impl Binding {
+    pub fn rewrite(&self, surfer: &mut impl Galactus) -> (Self, bool) {
+        let mut changed = false;
+        let value = shed(self.value.rewrite(surfer), &mut changed);
+        emit(
+            || Binding {
+                name: self.name.clone(),
+                role: self.role.clone(),
+                value,
             },
             changed,
             self,
@@ -98,6 +231,7 @@ impl Operation {
             Operation::Aggregate(x) => map(x.rewrite(surfer), Operation::Aggregate),
             Operation::Limit(x) => (Operation::Limit(*x), false),
             Operation::Binding(x, y) => map(y.rewrite(surfer), |y| Operation::Binding(x.clone(), y)),
+            Operation::Machine(n, r, id) => (Operation::Machine(n.clone(), r.clone(), id.clone()), false),
         }
     }
 }

--- a/rust/actyx/ax-aql/src/language/types.rs
+++ b/rust/actyx/ax-aql/src/language/types.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 use pest::pratt_parser::{Assoc, Op, PrattParser};
 use std::sync::Arc;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum Type {
     Atom(TypeAtom),
     Union(Arc<(Type, Type)>),
@@ -21,7 +21,7 @@ pub enum Type {
     Record(NonEmptyVec<(Label, Type)>),
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum TypeAtom {
     Null,
     Bool(Option<bool>),
@@ -31,7 +31,7 @@ pub enum TypeAtom {
     Universal,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum Label {
     String(NonEmptyString),
     Number(u64),

--- a/rust/actyx/ax-aql/src/language/types.rs
+++ b/rust/actyx/ax-aql/src/language/types.rs
@@ -1,10 +1,14 @@
-use super::{non_empty::NonEmptyString, parse_utils::P, parser::Rule};
+use super::{
+    non_empty::{NoElements, NonEmptyString},
+    parse_utils::P,
+    parser::Rule,
+};
 use crate::{
     language::{
         parse_utils::{Ext, Spanned},
         parser::{r_bool, r_nonempty_string, r_string, NoVal},
     },
-    NonEmptyVec,
+    Ident, NonEmptyVec,
 };
 use once_cell::sync::Lazy;
 use pest::pratt_parser::{Assoc, Op, PrattParser};
@@ -35,6 +39,20 @@ pub enum TypeAtom {
 pub enum Label {
     String(NonEmptyString),
     Number(u64),
+}
+
+impl From<Ident> for Label {
+    fn from(value: Ident) -> Self {
+        Label::String(value.0)
+    }
+}
+
+impl TryFrom<&str> for Label {
+    type Error = NoElements;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(Self::String(NonEmptyString::try_from(value)?))
+    }
 }
 
 pub fn r_type(p: P) -> anyhow::Result<Type> {

--- a/rust/actyx/ax-aql/src/language/types.rs
+++ b/rust/actyx/ax-aql/src/language/types.rs
@@ -1,0 +1,106 @@
+use super::{non_empty::NonEmptyString, parse_utils::P, parser::Rule};
+use crate::{
+    language::{
+        parse_utils::Ext,
+        parser::{r_bool, r_nonempty_string, r_string, NoVal},
+    },
+    NonEmptyVec,
+};
+use once_cell::sync::Lazy;
+use pest::pratt_parser::{Assoc, Op, PrattParser};
+use std::sync::Arc;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum Type {
+    Atom(TypeAtom),
+    Union(Arc<(Type, Type)>),
+    Intersection(Arc<(Type, Type)>),
+    Array(Arc<Type>),
+    Dict(Arc<Type>),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum TypeAtom {
+    Null,
+    Bool(Option<bool>),
+    Number(Option<u64>),
+    Timestamp,
+    String(Option<String>),
+    Tuple(NonEmptyVec<Type>),
+    Record(NonEmptyVec<(Label, Type)>),
+    Universal,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum Label {
+    String(NonEmptyString),
+    Number(u64),
+}
+
+pub fn r_type(p: P) -> anyhow::Result<Type> {
+    static PRATT: Lazy<PrattParser<Rule>> = Lazy::new(|| {
+        PrattParser::new()
+            .op(Op::infix(Rule::type_union, Assoc::Left))
+            .op(Op::infix(Rule::type_intersection, Assoc::Left))
+            .op(Op::postfix(Rule::type_array))
+            .op(Op::postfix(Rule::type_dict))
+    });
+    PRATT
+        .map_primary(|mut p| {
+            Ok(match p.as_rule() {
+                Rule::type_null => Type::Atom(TypeAtom::Null),
+                Rule::type_bool => Type::Atom(TypeAtom::Bool(None)),
+                Rule::bool => Type::Atom(TypeAtom::Bool(Some(r_bool(p)))),
+                Rule::type_number => Type::Atom(TypeAtom::Number(None)),
+                Rule::natural => Type::Atom(TypeAtom::Number(Some(p.natural()?))),
+                Rule::type_timestamp => Type::Atom(TypeAtom::Timestamp),
+                Rule::type_string => Type::Atom(TypeAtom::String(None)),
+                Rule::string => Type::Atom(TypeAtom::String(Some(r_string(p)?))),
+                Rule::type_tuple => {
+                    let ts = p
+                        .inner()?
+                        .filter(|p| p.as_rule() == Rule::r#type)
+                        .map(r_type)
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Type::Atom(TypeAtom::Tuple(NonEmptyVec::try_from(ts)?))
+                }
+                Rule::type_record => {
+                    let mut ts = vec![];
+                    let mut p = p
+                        .inner()?
+                        .filter(|p| !matches!(p.as_rule(), Rule::curlyl | Rule::curlyr | Rule::comma | Rule::colon));
+                    while let Some(mut label) = p.next() {
+                        let label = match label.as_rule() {
+                            Rule::nonempty_string => Label::String(r_nonempty_string(label)?),
+                            Rule::natural => Label::Number(label.natural()?),
+                            Rule::ident => Label::String(label.non_empty_string()?),
+                            _ => unexpected!(label),
+                        };
+                        let t = r_type(p.next().ok_or(NoVal("value"))?)?;
+                        ts.push((label, t));
+                    }
+                    Type::Atom(TypeAtom::Record(NonEmptyVec::try_from(ts)?))
+                }
+                Rule::type_paren => r_type(p.into_inner().nth(1).ok_or(NoVal("nested type"))?)?,
+                Rule::type_universal => Type::Atom(TypeAtom::Universal),
+                _ => unexpected!(p),
+            })
+        })
+        .map_infix(|l, op, r| {
+            Ok(match op.as_rule() {
+                Rule::type_union => Type::Union(Arc::new((l?, r?))),
+                Rule::type_intersection => Type::Intersection(Arc::new((l?, r?))),
+                _ => unexpected!(op),
+            })
+        })
+        .map_postfix(|t, p| {
+            t.and_then(|t| {
+                Ok(match p.as_rule() {
+                    Rule::type_array => Type::Array(Arc::new(t)),
+                    Rule::type_dict => Type::Dict(Arc::new(t)),
+                    _ => unexpected!(p),
+                })
+            })
+        })
+        .parse(p.into_inner())
+}

--- a/rust/actyx/ax-aql/src/language/workflow.rs
+++ b/rust/actyx/ax-aql/src/language/workflow.rs
@@ -79,30 +79,30 @@ impl<'a> WorkflowStep<'a> {
     pub fn get_events(&'a self) -> Vec<Span<'a, Ident>> {
         match self {
             WorkflowStep::Event { label, .. } => vec![label.clone()],
-            WorkflowStep::Retry { steps } => steps.into_iter().flat_map(|step| step.get_events()).collect(),
+            WorkflowStep::Retry { steps } => steps.iter().flat_map(|step| step.get_events()).collect(),
             WorkflowStep::Timeout { steps, label, .. } => steps
-                .into_iter()
+                .iter()
                 .flat_map(|step| step.get_events())
                 .chain(std::iter::once(label.clone()))
                 .collect(),
             WorkflowStep::Parallel { cases, .. } => cases
-                .into_iter()
-                .flat_map(|case| case.into_iter())
+                .iter()
+                .flat_map(|case| case.iter())
                 .flat_map(|step| step.get_events())
                 .collect(),
             WorkflowStep::Call { cases, .. } => cases
-                .into_iter()
-                .flat_map(|(_, steps)| steps.into_iter())
+                .iter()
+                .flat_map(|(_, steps)| steps.iter())
                 .flat_map(|step| step.get_events())
                 .collect(),
             WorkflowStep::Compensate { body, with } => body
-                .into_iter()
+                .iter()
                 .flat_map(|step| step.get_events())
-                .chain(with.into_iter().flat_map(|step| step.get_events()))
+                .chain(with.iter().flat_map(|step| step.get_events()))
                 .collect(),
             WorkflowStep::Choice { cases } => cases
-                .into_iter()
-                .flat_map(|case| case.into_iter())
+                .iter()
+                .flat_map(|case| case.iter())
                 .flat_map(|step| step.get_events())
                 .collect(),
         }

--- a/rust/actyx/ax-aql/src/language/workflow.rs
+++ b/rust/actyx/ax-aql/src/language/workflow.rs
@@ -1,0 +1,314 @@
+use super::{
+    parse_utils::{Ps, Spanned},
+    parser::{r_duration, r_simple_expr},
+};
+use crate::language::{
+    parse_utils::{Ext, Span, P},
+    parser::Rule,
+    Ident, NonEmptyVec, SimpleExpr,
+};
+use ax_types::Timestamp;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Workflow<'a> {
+    pub name: Ident,
+    pub args: NonEmptyVec<Span<'a, Participant>>,
+    pub steps: NonEmptyVec<WorkflowStep<'a>>,
+}
+
+impl<'a> Workflow<'a> {
+    pub fn name(&self) -> &Ident {
+        &self.name
+    }
+
+    pub fn args(&self) -> &NonEmptyVec<Span<'a, Participant>> {
+        &self.args
+    }
+
+    pub fn steps(&self) -> &NonEmptyVec<WorkflowStep> {
+        &self.steps
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Participant {
+    Role(Ident),
+    Unique(Ident),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WorkflowStep<'a> {
+    Event {
+        state: Option<Span<'a, Ident>>,
+        mode: EventMode,
+        label: Span<'a, Ident>,
+        participant: Span<'a, Ident>,
+        binders: Vec<Span<'a, Binding>>,
+    },
+    Retry {
+        steps: NonEmptyVec<WorkflowStep<'a>>,
+    },
+    Timeout {
+        micros: Span<'a, u64>,
+        steps: NonEmptyVec<WorkflowStep<'a>>,
+        mode: EventMode,
+        label: Span<'a, Ident>,
+        participant: Span<'a, Ident>,
+        binders: Vec<Span<'a, Binding>>,
+    },
+    Parallel {
+        count: Span<'a, u64>,
+        cases: NonEmptyVec<NonEmptyVec<WorkflowStep<'a>>>,
+    },
+    Call {
+        workflow: Span<'a, Ident>,
+        args: NonEmptyVec<Span<'a, Ident>>,
+        cases: NonEmptyVec<(Option<Span<'a, Ident>>, NonEmptyVec<WorkflowStep<'a>>)>,
+    },
+    Compensate {
+        body: NonEmptyVec<WorkflowStep<'a>>,
+        with: NonEmptyVec<WorkflowStep<'a>>,
+    },
+    Choice {
+        cases: NonEmptyVec<NonEmptyVec<WorkflowStep<'a>>>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EventMode {
+    Normal,
+    Return,
+    Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Binding {
+    pub name: Ident,
+    pub role: Ident,
+    pub value: SimpleExpr,
+}
+
+impl Binding {
+    pub fn name(&self) -> &Ident {
+        &self.name
+    }
+
+    pub fn role(&self) -> &Ident {
+        &self.role
+    }
+
+    pub fn value(&self) -> &SimpleExpr {
+        &self.value
+    }
+}
+
+pub fn r_workflow(p: P) -> anyhow::Result<Workflow> {
+    let mut p = p.into_inner();
+    let name_span = p.peek().unwrap().as_span();
+    let name = Ident(p.non_empty_string()?);
+    let mut args = vec![];
+    while matches!(p.next().unwrap().as_rule(), Rule::parenl | Rule::comma) {
+        let p = p.next().unwrap();
+        let span = p.as_span();
+        let mut p = p.into_inner();
+        let kind = p.next().unwrap();
+        let participant = match kind.as_rule() {
+            Rule::role => Participant::Role(Ident(p.non_empty_string()?)),
+            Rule::unique => Participant::Unique(Ident(p.non_empty_string()?)),
+            _ => unexpected!(kind),
+        };
+        args.push(Span::new(span, participant));
+    }
+    let steps = r_scope(p.next().unwrap())?;
+    Ok(Workflow {
+        name,
+        args: NonEmptyVec::try_from(args).spanned(name_span)?,
+        steps,
+    })
+}
+
+fn r_scope(p: P) -> anyhow::Result<NonEmptyVec<WorkflowStep>> {
+    let span = p.as_span();
+    Ok(p.into_inner()
+        .filter(|p| !matches!(p.as_rule(), Rule::curlyl | Rule::curlyr))
+        .map(r_step)
+        .collect::<Result<Vec<_>, _>>()?
+        .try_into()
+        .spanned(span)?)
+}
+
+fn r_step(p: P) -> anyhow::Result<WorkflowStep> {
+    Ok(match p.as_rule() {
+        Rule::wf_event => r_event(p)?,
+        Rule::wf_retry => WorkflowStep::Retry {
+            steps: r_scope(p.into_inner().nth(1).unwrap())?,
+        },
+        Rule::wf_timeout => r_timeout(p)?,
+        Rule::wf_parallel => {
+            let mut p = p.into_inner();
+            let parallel = p.next().unwrap();
+            let count = if p.peek().map(|p| p.as_rule()) == Some(Rule::natural) {
+                Some(Span::make(p.next().unwrap(), |mut p| p.natural())?)
+            } else {
+                None
+            };
+            let cases = r_cases(p)?;
+            WorkflowStep::Parallel {
+                count: count.unwrap_or_else(|| Span::new(parallel.as_span(), cases.len() as u64)),
+                cases,
+            }
+        }
+        Rule::wf_call => r_call(p)?,
+        Rule::wf_compensate => {
+            let mut p = p.into_inner();
+            let _compensate = p.next().unwrap();
+            let body = r_scope(p.next().unwrap())?;
+            let _with = p.next().unwrap();
+            let with = r_scope(p.next().unwrap())?;
+            WorkflowStep::Compensate { body, with }
+        }
+        Rule::wf_choice => {
+            let mut p = p.into_inner();
+            let _choice = p.next().unwrap();
+            let cases = r_cases(p)?;
+            WorkflowStep::Choice { cases }
+        }
+        _ => unexpected!(p),
+    })
+}
+
+fn r_event(p: P<'_>) -> Result<WorkflowStep<'_>, anyhow::Error> {
+    let mut p = p.into_inner();
+    let state = if p.peek().unwrap().as_rule() == Rule::wf_state {
+        let mut ident = p.next().unwrap().single()?;
+        let _colon = p.next().unwrap();
+        Some(Span::new(ident.as_span(), Ident(ident.non_empty_string()?)))
+    } else {
+        None
+    };
+    let mode = match p.peek().unwrap().as_rule() {
+        Rule::r#return => {
+            p.next().unwrap();
+            EventMode::Return
+        }
+        Rule::fail => {
+            p.next().unwrap();
+            EventMode::Fail
+        }
+        _ => EventMode::Normal,
+    };
+    let label = Span::make(p.next().unwrap(), |mut p| Ok(Ident(p.non_empty_string()?)))?;
+    let _at = p.next().unwrap();
+    let participant = Span::make(p.next().unwrap(), |mut p| Ok(Ident(p.non_empty_string()?)))?;
+    let binders = p.map(r_binding).collect::<Result<Vec<_>, _>>()?;
+    Ok(WorkflowStep::Event {
+        state,
+        mode,
+        label,
+        participant,
+        binders,
+    })
+}
+
+fn r_binding(p: P) -> anyhow::Result<Span<Binding>> {
+    let span = p.as_span();
+    let mut p = p.into_inner();
+    let _curlyl = p.next().unwrap();
+    let name = Ident(p.next().unwrap().non_empty_string()?);
+    let _colon = p.next().unwrap();
+    let role = Ident(p.next().unwrap().non_empty_string()?);
+    let _arrowl = p.next().unwrap();
+    let value = r_simple_expr(
+        p.next().unwrap(),
+        super::parser::Context::Simple { now: Timestamp::now() },
+    )?;
+    Ok(Span::new(span, Binding { name, role, value }))
+}
+
+fn r_timeout(p: P) -> anyhow::Result<WorkflowStep> {
+    let mut p = p.into_inner();
+    let _timeout = p.next().unwrap();
+    let duration = Span::make(p.next().unwrap(), |p| r_duration(p))?;
+    let steps = r_scope(p.next().unwrap())?;
+    let WorkflowStep::Event {
+        state: _,
+        mode,
+        label,
+        participant,
+        binders,
+    } = r_event(p.next().unwrap())?
+    else {
+        unreachable!()
+    };
+    Ok(WorkflowStep::Timeout {
+        micros: duration,
+        steps,
+        mode,
+        label,
+        participant,
+        binders,
+    })
+}
+
+fn r_cases(mut p: Ps) -> anyhow::Result<NonEmptyVec<NonEmptyVec<WorkflowStep>>> {
+    let mut cases = vec![];
+    let _curly = p.next().unwrap();
+    let case = p.next().unwrap();
+    while p.peek().is_some() {
+        cases.push(
+            (&mut p)
+                .take_while(|p| !matches!(p.as_rule(), Rule::case | Rule::curlyr))
+                .map(r_step)
+                .collect::<Result<Vec<_>, _>>()?
+                .try_into()
+                .spanned(case.as_span())?,
+        );
+    }
+    Ok(NonEmptyVec::try_from(cases).spanned(case.as_span())?)
+}
+
+fn r_call(p: P) -> anyhow::Result<WorkflowStep> {
+    let mut p = p.into_inner();
+    let _match = p.next().unwrap();
+    let workflow = Span::make(p.next().unwrap(), |mut p| Ok(Ident(p.non_empty_string()?)))?;
+    let paren = p.next().unwrap();
+    let args = (&mut p)
+        .take_while(|p| p.as_rule() != Rule::parenr)
+        .filter(|p| p.as_rule() == Rule::ident)
+        .map(|p| Span::make(p, |mut p| Ok(Ident(p.non_empty_string()?))))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut cases = vec![];
+    let curly = p.next().unwrap();
+    while let Some(p) = p.next() {
+        if p.as_rule() == Rule::curlyr {
+            break;
+        }
+        let mut p = p.into_inner();
+        let _case = p.next().unwrap();
+        let pat = p.next().unwrap();
+        let label = if pat.as_rule() == Rule::ident {
+            Some(Span::make(pat, |mut p| Ok(Ident(p.non_empty_string()?)))?)
+        } else {
+            None
+        };
+        let dblarrowr = p.next().unwrap();
+        let steps = p.map(r_step).collect::<Result<Vec<_>, _>>()?;
+        cases.push((label, NonEmptyVec::try_from(steps).spanned(dblarrowr.as_span())?));
+    }
+    Ok(WorkflowStep::Call {
+        workflow,
+        args: NonEmptyVec::try_from(args).spanned(paren.as_span())?,
+        cases: NonEmptyVec::try_from(cases).spanned(curly.as_span())?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Query;
+
+    #[test]
+    fn ex1() {
+        let q = "WORKFLOW qg9gZK(UNIQUE kCSxum) { MATCH se5Q7Y(dJKW1Y) { CASE * => PARALLEL 15668459163393358498 { CASE exLLu3: ckZo9J @ BjfPBLR } } } FROM allEvents ORDER DESC END";
+        Query::parse(q).unwrap();
+    }
+}

--- a/rust/actyx/ax-aql/src/language/workflow.rs
+++ b/rust/actyx/ax-aql/src/language/workflow.rs
@@ -228,7 +228,7 @@ fn r_binding(p: P) -> anyhow::Result<Span<Binding>> {
 fn r_timeout(p: P) -> anyhow::Result<WorkflowStep> {
     let mut p = p.into_inner();
     let _timeout = p.next().unwrap();
-    let duration = Span::make(p.next().unwrap(), |p| r_duration(p))?;
+    let duration = Span::make(p.next().unwrap(), r_duration)?;
     let steps = r_scope(p.next().unwrap())?;
     let WorkflowStep::Event {
         state: _,
@@ -279,7 +279,7 @@ fn r_call(p: P) -> anyhow::Result<WorkflowStep> {
         .collect::<Result<Vec<_>, _>>()?;
     let mut cases = vec![];
     let curly = p.next().unwrap();
-    while let Some(p) = p.next() {
+    for p in p {
         if p.as_rule() == Rule::curlyr {
             break;
         }

--- a/rust/actyx/ax-aql/src/language/workflow.rs
+++ b/rust/actyx/ax-aql/src/language/workflow.rs
@@ -79,7 +79,11 @@ impl<'a> WorkflowStep<'a> {
         match self {
             WorkflowStep::Event { label, .. } => vec![label.clone()],
             WorkflowStep::Retry { steps } => steps.into_iter().flat_map(|step| step.get_events()).collect(),
-            WorkflowStep::Timeout { steps, .. } => steps.into_iter().flat_map(|step| step.get_events()).collect(),
+            WorkflowStep::Timeout { steps, label, .. } => steps
+                .into_iter()
+                .flat_map(|step| step.get_events())
+                .chain(std::iter::once(label.clone()))
+                .collect(),
             WorkflowStep::Parallel { cases, .. } => cases
                 .into_iter()
                 .flat_map(|case| case.into_iter())

--- a/rust/actyx/ax-core/Cargo.toml
+++ b/rust/actyx/ax-core/Cargo.toml
@@ -119,6 +119,11 @@ zstd = "0.9.2"
 stacker = "0.1.15"
 
 [dev-dependencies]
+ax_types = { version = "0.1.0", path = "../ax-types", features = [
+  "sqlite",
+  "arb",
+] }
+
 anyhow = { version = "1.0.52", features = ["backtrace"] }
 assert_cmd = "2.0.2"
 criterion = { version = "0.3.5", features = ["html_reports", "async_tokio"] }

--- a/rust/actyx/ax-core/src/api/files/pinner.rs
+++ b/rust/actyx/ax-core/src/api/files/pinner.rs
@@ -150,7 +150,7 @@ SELECT _.cid"#,
                             now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
                         ))
                         .expect("valid query")
-                        .forget_pragmas(),
+                        .forget_pragmas_and_workflows(),
                     ))
                     .await
                 {

--- a/rust/actyx/ax-core/src/runtime/operation/mod.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/mod.rs
@@ -1,3 +1,6 @@
+mod aggregate;
+mod validation;
+
 use crate::runtime::{
     error::{RuntimeError, RuntimeFailure},
     eval::Context,
@@ -7,7 +10,6 @@ use crate::runtime::{
 use ax_aql::{NonEmptyVec, SimpleExpr, SpreadExpr};
 use ax_types::service::Order;
 
-mod aggregate;
 use futures::{future::BoxFuture, FutureExt};
 use std::{future::ready, num::NonZeroU64};
 

--- a/rust/actyx/ax-core/src/runtime/operation/mod.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/mod.rs
@@ -63,6 +63,7 @@ impl From<ax_aql::Operation> for Operation {
             ax_aql::Operation::Aggregate(a) => Self::Aggregate(a),
             ax_aql::Operation::Limit(l) => Self::Limit(l),
             ax_aql::Operation::Binding(n, e) => Self::Binding(n, e),
+            ax_aql::Operation::Machine(_n, _r, _id) => Self::Binding("TODO".to_string(), SimpleExpr::Bool(false)),
         }
     }
 }

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -423,11 +423,10 @@ mod test {
         assert!(
             validate_tuple(
                 &cbor,
-                &NonEmptyVec::try_from(vec![
+                &[
                     Type::Atom(TypeAtom::Number(None)),
                     Type::Atom(TypeAtom::Number(Some(100)))
-                ])
-                .expect("a non empty vec")
+                ]
             )
             .is_ok(),
             "TUPLE contents are not (NUMBER, NUMBER(100)"
@@ -443,12 +442,11 @@ mod test {
         assert!(
             validate_tuple(
                 &cbor,
-                &NonEmptyVec::try_from(vec![
+                &[
                     Type::Atom(TypeAtom::Number(None)),
                     Type::Atom(TypeAtom::Number(None)),
                     Type::Atom(TypeAtom::Number(None)),
-                ])
-                .expect("a non empty vec")
+                ]
             )
             .is_err(),
             "TUPLE contents are (NUMBER, NUMBER, NUMBER)"
@@ -464,12 +462,11 @@ mod test {
         assert!(
             validate_tuple(
                 &cbor,
-                &NonEmptyVec::try_from(vec![
+                &[
                     Type::Atom(TypeAtom::Number(Some(10))),
                     Type::Atom(TypeAtom::Number(Some(100))),
                     Type::Atom(TypeAtom::Number(None)),
-                ])
-                .expect("a non empty vec")
+                ]
             )
             .is_err(),
             "TUPLE contents are (NUMBER(10), NUMBER(100), NUMBER)"
@@ -485,11 +482,7 @@ mod test {
         assert!(
             validate_tuple(
                 &cbor,
-                &NonEmptyVec::try_from(vec![
-                    Type::Atom(TypeAtom::Number(None)),
-                    Type::Atom(TypeAtom::String(None)),
-                ])
-                .expect("a non empty vec")
+                &[Type::Atom(TypeAtom::Number(None)), Type::Atom(TypeAtom::String(None))]
             )
             .is_err(),
             "TUPLE contents are (NUMBER, STRING)"

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -96,7 +96,6 @@ fn validate_string(value: &CborValue, string_refinement: &Option<String>) -> any
 
 /// Check if a CBOR value is an array. Can also be used to check for tuples (following RFC 7049).
 fn validate_array(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
-    // NOTE(duarte): this validate is incomplete because we're not supporting subtyping, hence, we're just checking for arrays
     if let Some(values) = value.as_array() {
         for (i, value) in values.iter().enumerate() {
             if let Err(err) = validate(&value.decode(), ty) {

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -1,0 +1,754 @@
+use std::{
+    borrow::{Borrow, Cow},
+    fmt::Display,
+};
+
+use anyhow::Context;
+use ax_aql::{Label, NonEmptyVec, Type, TypeAtom};
+use cbor_data::{value::Number, CborBuilder, CborValue, Encoder};
+
+// NOTE: check tarpaulin for test coverage, its always hard to ensure every path was checked and
+// in this case, it would be really useful: https://github.com/xd009642/tarpaulin
+
+/// Check if a CBOR value is null.
+fn validate_null(value: &CborValue) -> Result<(), anyhow::Error> {
+    if value.is_null() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be null"))
+    }
+}
+
+/// Check if a CBOR value is a boolean or a boolean refinement (i.e. `true` or `false`).
+fn validate_bool(value: &CborValue, bool_refinement: &Option<bool>) -> Result<(), anyhow::Error> {
+    if let Some(value) = value.as_bool() {
+        if let Some(bool_refinement) = bool_refinement {
+            if value == *bool_refinement {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(
+                    "type mismatch, expected value to be {}, received {} instead",
+                    bool_refinement,
+                    value
+                ))
+            }
+        } else {
+            Ok(())
+        }
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be a boolean"))
+    }
+}
+
+/// Check if a CBOR value is an integer or an integer refinement (e.g. `10`).
+fn validate_number(value: &CborValue, number_refinement: &Option<u64>) -> Result<(), anyhow::Error> {
+    if let Some(Number::Int(value)) = value.as_number() {
+        if let Ok(value) = u64::try_from(*value) {
+            if let Some(number_refinement) = number_refinement {
+                if value == *number_refinement {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "type mismatch, expected value to be {}, received {} instead",
+                        number_refinement,
+                        value
+                    ))
+                }
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "type mismatch, expected value to be a 64-bit integer but received a 128-bit integer instead"
+            ))
+        }
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be an integer"))
+    }
+}
+
+/// Check if a CBOR value is a timestamp.
+fn validate_timestamp(value: &CborValue) -> Result<(), anyhow::Error> {
+    if value.as_timestamp().is_some() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be a timestamp"))
+    }
+}
+
+/// Check if a CBOR value is a string or a string refinement (e.g. "Hello").
+fn validate_string(value: &CborValue, string_refinement: &Option<String>) -> Result<(), anyhow::Error> {
+    if let Some(value) = value.as_str() {
+        if let Some(refinement) = string_refinement {
+            if value == refinement {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!(
+                    "type mismatch, expected value to be {}, received {} instead",
+                    refinement,
+                    value
+                ))
+            }
+        } else {
+            Ok(())
+        }
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be a string"))
+    }
+}
+
+/// Check if a CBOR value is an array. Can also be used to check for tuples (following RFC 7049).
+fn validate_array(value: &CborValue) -> Result<(), anyhow::Error> {
+    // NOTE(duarte): this validate is incomplete because we're not supporting subtyping, hence, we're just checking for arrays
+    if value.as_array().is_some() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be an array"))
+    }
+}
+
+fn validate_tuple(value: &CborValue, length: usize) -> Result<(), anyhow::Error> {
+    if let Some(array) = value.as_array() {
+        if array.len() != length {
+            Err(anyhow::anyhow!(
+                "type mismatch, expected tuple to have length {} got {} instead",
+                length,
+                array.len()
+            ))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be an array"))
+    }
+}
+
+/// Check if a CBOR value is a dictionary.
+fn validate_dict(value: &CborValue) -> Result<(), anyhow::Error> {
+    if value.as_dict().is_some() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("type mismatch, expected value to be a dictionary"))
+    }
+}
+
+// The idea is that this function will only check for Atoms,
+// the issue is that a Record can nest arbitrarily deep and may use non-atom types
+// ideally, I would like to _not_ use recursion since we already had the stack issue in other places;
+// so we either ignore records here and handle them somewhere else or we handle them here, some how
+fn validate_atom(value: &CborValue, ty: &TypeAtom) -> Result<(), anyhow::Error> {
+    match ty {
+        TypeAtom::Null => validate_null(value),
+        TypeAtom::Bool(refinement) => validate_bool(value, refinement),
+        TypeAtom::Number(refinement) => validate_number(value, refinement),
+        TypeAtom::Timestamp => validate_timestamp(value),
+        TypeAtom::String(refinement) => validate_string(value, refinement),
+        TypeAtom::Universal => Ok(()),
+    }
+}
+
+fn validate_record(value: &CborValue, ty: &NonEmptyVec<(Label, Type)>) -> Result<(), anyhow::Error> {
+    if let Some(value) = value.as_dict() {
+        for (label, ty) in ty.iter() {
+            match label {
+                Label::String(string) => {
+                    let cbor = CborBuilder::new().encode_str(string);
+                    let cbor = Cow::Owned(cbor);
+                    if let Some(value) = value.get(&cbor) {
+                        if let e @ Err(_) = validate(&value.decode(), ty) {
+                            return e;
+                        }
+                    } else {
+                        return Err(anyhow::anyhow!("label {} does not exist in record", string));
+                    }
+                }
+                Label::Number(number) => {
+                    let number = i128::from(*number);
+                    let number = Number::Int(number);
+                    let cbor = CborBuilder::new().encode_number(&number);
+                    let cbor = Cow::Owned(cbor);
+                    if let Some(value) = value.get(&cbor) {
+                        if let e @ Err(_) = validate(&value.decode(), ty) {
+                            return e;
+                        }
+                    } else {
+                        return Err(anyhow::anyhow!("label {:?} does not exist in record", number));
+                    }
+                }
+            }
+        }
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("expected a record (dict)"))
+    }
+}
+
+// Using logic rules and De Morgan laws to rewrite intersections and unions before we reach this method
+// would (probably) allow us to write a better (i.e. simpler) and more performant validator
+fn validate_union(value: &CborValue, ty: &(Type, Type)) -> Result<(), anyhow::Error> {
+    // Since the union operation is commutative, we always evaluate the most specific type first
+    // TODO: add tests
+    match ty.borrow() {
+        // Atom
+        (Type::Atom(left), Type::Atom(right)) => {
+            validate_atom(value, &left).or_else(|err| validate_atom(value, &right).context(err))
+        }
+        (Type::Atom(atom), Type::Union(union)) | (Type::Union(union), Type::Atom(atom)) => {
+            validate_atom(value, &atom).or_else(|err| validate_union(value, union).context(err))
+        }
+        (Type::Atom(atom), Type::Intersection(intersection)) | (Type::Intersection(intersection), Type::Atom(atom)) => {
+            validate_atom(value, &atom).or_else(|err| validate_intersection(value, intersection).context(err))
+        }
+        (Type::Atom(atom), Type::Array(_)) | (Type::Array(_), Type::Atom(atom)) => {
+            // Arrays and tuples since according to RFC 7049 they're "interchangeable"
+            validate_atom(value, &atom).or_else(|err| validate_array(value).context(err))
+        }
+        (Type::Atom(atom), Type::Tuple(tuple)) | (Type::Tuple(tuple), Type::Atom(atom)) => {
+            validate_atom(value, atom).or_else(|err| validate_tuple(value, tuple.len()).context(err))
+        }
+        (Type::Atom(atom), Type::Dict(_)) | (Type::Dict(_), Type::Atom(atom)) => {
+            validate_atom(value, &atom).or_else(|err| validate_dict(value).context(err))
+        }
+        (Type::Atom(atom), Type::Record(record)) | (Type::Record(record), Type::Atom(atom)) => {
+            validate_atom(value, atom).or_else(|err| validate_record(value, record).context(err))
+        }
+        (Type::Array(_), Type::Array(_)) => validate_array(value), // TODO: support sub-typing
+        (Type::Array(_), Type::Union(union)) | (Type::Union(union), Type::Array(_)) => {
+            validate_array(value).or_else(|err| validate_union(value, union).context(err))
+        }
+        (Type::Array(_), Type::Intersection(intersection)) | (Type::Intersection(intersection), Type::Array(_)) => {
+            validate_array(value).or_else(|err| validate_intersection(value, intersection).context(err))
+        }
+        (Type::Array(_), Type::Dict(_)) | (Type::Dict(_), Type::Array(_)) => {
+            validate_array(value).or_else(|err| validate_dict(value).context(err))
+        }
+        (Type::Array(_), Type::Record(record)) | (Type::Record(record), Type::Array(_)) => {
+            validate_array(value).or_else(|err| validate_record(value, record).context(err))
+        }
+        (Type::Array(_), Type::Tuple(tuple)) | (Type::Tuple(tuple), Type::Array(_)) => {
+            validate_tuple(value, tuple.len()).or_else(|err| validate_array(value).context(err))
+        }
+        (Type::Dict(_), Type::Dict(_)) => validate_dict(value), // TODO: add sub-typing
+        (Type::Dict(_), Type::Union(union)) | (Type::Union(union), Type::Dict(_)) => {
+            validate_dict(value).or_else(|err| validate_union(value, union).context(err))
+        }
+        (Type::Dict(_), Type::Intersection(intersection)) | (Type::Intersection(intersection), Type::Dict(_)) => {
+            validate_dict(value).or_else(|err| validate_intersection(value, intersection).context(err))
+        }
+        (Type::Dict(_), Type::Tuple(tuple)) | (Type::Tuple(tuple), Type::Dict(_)) => {
+            validate_dict(value).or_else(|err| validate_tuple(value, tuple.len()).context(err))
+        }
+        (Type::Dict(_), Type::Record(record)) | (Type::Record(record), Type::Dict(_)) => {
+            validate_dict(value).or_else(|err| validate_record(value, record).context(err))
+        }
+        (Type::Tuple(left), Type::Tuple(right)) => {
+            // TODO: add further sub-typing
+            validate_tuple(value, left.len()).or_else(|err| validate_tuple(value, right.len()).context(err))
+        }
+        (Type::Tuple(tuple), Type::Union(union)) | (Type::Union(union), Type::Tuple(tuple)) => {
+            validate_tuple(value, tuple.len()).or_else(|err| validate_union(value, union).context(err))
+        }
+        (Type::Tuple(tuple), Type::Intersection(intersection))
+        | (Type::Intersection(intersection), Type::Tuple(tuple)) => {
+            validate_tuple(value, tuple.len()).or_else(|err| validate_intersection(value, intersection).context(err))
+        }
+        (Type::Tuple(tuple), Type::Record(record)) | (Type::Record(record), Type::Tuple(tuple)) => {
+            validate_tuple(value, tuple.len()).or_else(|err| validate_record(value, record).context(err))
+        }
+        (Type::Record(left), Type::Record(right)) => {
+            validate_record(value, left).or_else(|err| validate_record(value, right).context(err))
+        }
+        (Type::Record(record), Type::Union(union)) | (Type::Union(union), Type::Record(record)) => {
+            // This is kind of a bet that the union will be shallower than the record
+            validate_union(value, union).or_else(|err| validate_record(value, record).context(err))
+        }
+        (Type::Record(record), Type::Intersection(intersection))
+        | (Type::Intersection(intersection), Type::Record(record)) => {
+            // This is kind of a bet that the intersection will be shallower than the record
+            validate_intersection(value, intersection).or_else(|err| validate_record(value, record).context(err))
+        }
+        (Type::Union(left), Type::Union(right)) => {
+            validate_union(value, left).or_else(|err| validate_union(value, right).context(err))
+        }
+        (Type::Union(union), Type::Intersection(intersection))
+        | (Type::Intersection(intersection), Type::Union(union)) => {
+            validate_union(value, union).or_else(|err| validate_intersection(value, intersection).context(err))
+        }
+        (Type::Intersection(left), Type::Intersection(right)) => {
+            validate_intersection(value, left).or_else(|err| validate_intersection(value, right).context(err))
+        }
+    }
+}
+
+fn validate_intersection(value: &CborValue, ty: &(Type, Type)) -> Result<(), anyhow::Error> {
+    match ty.borrow() {
+        (Type::Atom(left), Type::Atom(right)) => {
+            intersect_atoms(left, right).and_then(|intersection| validate_atom(value, &intersection))
+        }
+        (Type::Atom(atom), Type::Union(union)) | (Type::Union(union), Type::Atom(atom)) => {
+            validate_atom(value, atom).and_then(|_| validate_union(value, union))
+        }
+        (Type::Atom(atom), Type::Intersection(intersection)) | (Type::Intersection(intersection), Type::Atom(atom)) => {
+            validate_atom(value, atom).and_then(|_| validate_intersection(value, intersection))
+        }
+        (Type::Array(_), Type::Array(_)) => validate_array(value), // TODO: handle subtyping
+        (Type::Array(_), Type::Union(union)) | (Type::Union(union), Type::Array(_)) => {
+            validate_array(value).and_then(|_| validate_union(value, union))
+        }
+        (Type::Array(_), Type::Intersection(intersection)) | (Type::Intersection(intersection), Type::Array(_)) => {
+            validate_array(value).and_then(|_| validate_intersection(value, intersection))
+        }
+        (Type::Dict(_), Type::Dict(_)) => validate_dict(value), // TODO: handle subtyping
+        (Type::Dict(_), Type::Union(union)) | (Type::Union(union), Type::Dict(_)) => {
+            validate_dict(value).and_then(|_| validate_union(value, union))
+        }
+        (Type::Dict(_), Type::Intersection(intersection)) | (Type::Intersection(intersection), Type::Dict(_)) => {
+            validate_dict(value).and_then(|_| validate_intersection(value, intersection))
+        }
+        (Type::Tuple(left), Type::Tuple(right)) => {
+            // TODO: add subtyping
+            if left.len() == right.len() {
+                validate_tuple(value, left.len())
+            } else {
+                Err(anyhow::anyhow!("invalid intersection"))
+            }
+        }
+        (Type::Tuple(tuple), Type::Union(union)) | (Type::Union(union), Type::Tuple(tuple)) => {
+            validate_tuple(value, tuple.len()).and_then(|_| validate_union(value, union))
+        }
+        (Type::Tuple(tuple), Type::Intersection(intersection))
+        | (Type::Intersection(intersection), Type::Tuple(tuple)) => {
+            validate_tuple(value, tuple.len()).and_then(|_| validate_intersection(value, intersection))
+        }
+        (Type::Record(left), Type::Record(right)) => {
+            // TODO: we can intersect the records to get either a single one or an error
+            // such approach should make this more efficient
+            validate_record(value, left).and_then(|_| validate_record(value, right))
+        }
+        (Type::Record(record), Type::Union(union)) | (Type::Union(union), Type::Record(record)) => {
+            validate_record(value, record).and_then(|_| validate_union(value, union))
+        }
+        (Type::Record(record), Type::Intersection(intersection))
+        | (Type::Intersection(intersection), Type::Record(record)) => {
+            validate_record(value, record).and_then(|_| validate_intersection(value, intersection))
+        }
+        (Type::Union(left), Type::Union(right)) => {
+            validate_union(value, left).and_then(|_| validate_union(value, right))
+        }
+        (Type::Intersection(left), Type::Intersection(right)) => {
+            validate_intersection(value, left).and_then(|_| validate_intersection(value, right))
+        }
+        (Type::Union(union), Type::Intersection(intersection))
+        | (Type::Intersection(intersection), Type::Union(union)) => {
+            // Assuming that the intersection will result in an acceptance/rejection "faster"
+            validate_intersection(value, intersection).and_then(|_| validate_union(value, union))
+        }
+        _ => {
+            // All other intersections are invalid!
+            // Theoretically, this should be unreachable as it should be caught earlier by the type checker
+            Err(anyhow::anyhow!("invalid intersection"))
+        }
+    }
+}
+
+fn validate(value: &CborValue, ty: &Type) -> Result<(), anyhow::Error> {
+    match ty {
+        Type::Atom(atom) => validate_atom(value, atom),
+        Type::Union(union) => validate_union(value, union),
+        Type::Intersection(intersection) => validate_intersection(value, intersection),
+        Type::Array(_) => validate_array(value),
+        Type::Dict(_) => validate_dict(value),
+        Type::Tuple(tuple) => validate_tuple(value, tuple.len()),
+        Type::Record(record) => validate_record(value, record),
+    }
+}
+
+/// Intersect refinements. Intersecting two absent refinements or an absent refinement and an existing one is always successful.
+///
+/// For example:
+/// ```text
+/// BOOL & BOOL => BOOL
+/// true & BOOL => true
+/// true & true => true
+/// true & false => !
+/// ```
+fn intersect_refinement<T: Eq + Display + Clone>(
+    left: &Option<T>,
+    right: &Option<T>,
+) -> Result<Option<T>, anyhow::Error> {
+    match (left, right) {
+        (None, None) => Ok(None),
+        (None, Some(r)) => Ok(Some(r.clone())),
+        (Some(l), None) => Ok(Some(l.clone())),
+        (Some(l), Some(r)) => {
+            if l == r {
+                Ok(Some(l.clone()))
+            } else {
+                Err(anyhow::anyhow!("failed to intersect {} and {}", l, r))
+            }
+        }
+    }
+}
+
+// NOTE(duarte): ideally, some of these methods, instead of returning an error, should return a "Never" type
+// that then gets translated to an error, in the most adequate place
+
+/// Intersect atoms. As a rule of thumb, if your atoms are not of the same kind they will not intersect, furthermore,
+/// if both atoms are refinable see [`intersect_refinement`] for more information.
+fn intersect_atoms(left: &TypeAtom, right: &TypeAtom) -> Result<TypeAtom, anyhow::Error> {
+    match (left, right) {
+        (TypeAtom::Bool(l), TypeAtom::Bool(r)) => intersect_refinement(l, r).map(|r| (TypeAtom::Bool(r))),
+        (TypeAtom::String(l), TypeAtom::String(r)) => intersect_refinement(l, r).map(|r| (TypeAtom::String(r))),
+        (TypeAtom::Number(l), TypeAtom::Number(r)) => intersect_refinement(l, r).map(|r| (TypeAtom::Number(r))),
+        // This one also covers Universal & Universal
+        (TypeAtom::Universal, atom) | (atom, TypeAtom::Universal) => Ok(atom.clone()),
+        // TODO(duarte): figure out a better error message
+        (left, right) => Err(anyhow::anyhow!("failed to intersect {:?} and {:?}", left, right)),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use crate::runtime::operation::validation::validate_union;
+
+    use super::{
+        validate_array, validate_atom, validate_bool, validate_dict, validate_intersection, validate_null,
+        validate_number, validate_record, validate_string, validate_timestamp, validate_tuple,
+    };
+
+    use ax_aql::{Label, Type, TypeAtom};
+    use cbor_data::{
+        value::{Precision, Timestamp},
+        CborBuilder, Encoder,
+    };
+
+    #[test]
+    fn test_validate_null() {
+        let cbor = CborBuilder::new().encode_null();
+        let cbor = cbor.decode();
+        assert!(validate_null(&cbor).is_ok());
+    }
+
+    #[test]
+    fn test_validate_null_fail() {
+        let cbor = CborBuilder::new().encode_i64(100);
+        let cbor = cbor.decode();
+        assert!(validate_null(&cbor).is_err());
+    }
+
+    #[test]
+    fn test_validate_bool() {
+        let cbor = CborBuilder::new().encode_bool(false);
+        let cbor = cbor.decode();
+        assert!(validate_bool(&cbor, &None).is_ok());
+        assert!(validate_bool(&cbor, &Some(false)).is_ok());
+        assert!(validate_bool(&cbor, &Some(true)).is_err());
+    }
+
+    #[test]
+    fn test_validate_bool_fail() {
+        let cbor = CborBuilder::new().encode_i64(10);
+        let cbor = cbor.decode();
+        assert!(validate_bool(&cbor, &None).is_err());
+        assert!(validate_bool(&cbor, &Some(false)).is_err());
+    }
+
+    #[test]
+    fn test_validate_number() {
+        let cbor = CborBuilder::new().encode_i64(10);
+        let cbor = cbor.decode();
+        assert!(validate_number(&cbor, &None).is_ok());
+        assert!(validate_number(&cbor, &Some(10)).is_ok());
+        assert!(validate_number(&cbor, &Some(50)).is_err());
+    }
+
+    #[test]
+    fn test_validate_number_fail() {
+        let cbor = CborBuilder::new().encode_f64(0.100);
+        let cbor = cbor.decode();
+        assert!(validate_number(&cbor, &None).is_err());
+        assert!(validate_number(&cbor, &Some(100)).is_err());
+    }
+
+    #[test]
+    fn test_validate_timestamp() {
+        let timestamp = Timestamp::new(876523558, 0, 0);
+        let cbor = CborBuilder::new().encode_timestamp(timestamp, Precision::Seconds);
+        let cbor = cbor.decode();
+        assert!(validate_timestamp(&cbor).is_ok());
+    }
+
+    #[test]
+    fn test_validate_timestamp_fail() {
+        let cbor = CborBuilder::new().encode_str("value");
+        let cbor = cbor.decode();
+        assert!(validate_timestamp(&cbor).is_err());
+    }
+
+    #[test]
+    fn test_validate_string() {
+        let cbor = CborBuilder::new().encode_str("Olá mundo!");
+        let cbor = cbor.decode();
+        assert!(validate_string(&cbor, &None).is_ok());
+        assert!(validate_string(&cbor, &Some("Olá mundo!".to_string())).is_ok());
+        assert!(validate_string(&cbor, &Some("Adeus mundo!".to_string())).is_err());
+    }
+
+    #[test]
+    fn test_validate_string_fail() {
+        let cbor = CborBuilder::new().encode_i64(64);
+        let cbor = cbor.decode();
+        assert!(validate_string(&cbor, &None).is_err());
+        assert!(validate_string(&cbor, &Some("Adeus mundo!".to_string())).is_err());
+    }
+
+    #[test]
+    fn test_validate_universal() {
+        let cbor = CborBuilder::new().encode_null();
+        let cbor = cbor.decode();
+        assert!(validate_atom(&cbor, &TypeAtom::Universal).is_ok());
+
+        let cbor = CborBuilder::new().encode_bool(true);
+        let cbor = cbor.decode();
+        assert!(validate_atom(&cbor, &TypeAtom::Universal).is_ok());
+
+        let cbor = CborBuilder::new().encode_i64(100);
+        let cbor = cbor.decode();
+        assert!(validate_atom(&cbor, &TypeAtom::Universal).is_ok());
+
+        let timestamp = Timestamp::new(876523558, 0, 0);
+        let cbor = CborBuilder::new().encode_timestamp(timestamp, Precision::Seconds);
+        let cbor = cbor.decode();
+        assert!(validate_atom(&cbor, &TypeAtom::Universal).is_ok());
+
+        let cbor = CborBuilder::new().encode_str("Hello!");
+        let cbor = cbor.decode();
+        assert!(validate_atom(&cbor, &TypeAtom::Universal).is_ok());
+    }
+
+    #[test]
+    fn test_validate_array() {
+        let cbor = CborBuilder::new().encode_array(|builder| {
+            builder.encode_u64(10).encode_u64(100);
+        });
+        let cbor = cbor.decode();
+        assert!(validate_array(&cbor).is_ok());
+    }
+
+    #[test]
+    fn test_validate_array_fail() {
+        let cbor = CborBuilder::new().encode_dict(|builder| {
+            builder.with_key("hello", |b| b.encode_str("world"));
+        });
+        let cbor = cbor.decode();
+        assert!(validate_array(&cbor).is_err());
+    }
+
+    #[test]
+    fn test_validate_tuple() {
+        let cbor = CborBuilder::new().encode_array(|builder| {
+            builder.encode_u64(10).encode_u64(100);
+        });
+        let cbor = cbor.decode();
+        assert!(validate_tuple(&cbor, 2).is_ok());
+    }
+
+    #[test]
+    fn test_validate_tuple_fail() {
+        let cbor = CborBuilder::new().encode_array(|builder| {
+            builder.encode_u64(10).encode_u64(100);
+        });
+        let cbor = cbor.decode();
+        assert!(validate_tuple(&cbor, 4).is_err());
+
+        let cbor = CborBuilder::new().encode_dict(|builder| {
+            builder.with_key("hello", |b| b.encode_str("world"));
+        });
+        let cbor = cbor.decode();
+        assert!(validate_tuple(&cbor, 3).is_err());
+    }
+
+    #[test]
+    fn test_validate_dict() {
+        let cbor = CborBuilder::new().encode_dict(|builder| {
+            builder.with_key("hello", |b| b.encode_str("world"));
+        });
+        let cbor = cbor.decode();
+        assert!(validate_dict(&cbor).is_ok());
+    }
+
+    #[test]
+    fn test_validate_dict_fail() {
+        let cbor = CborBuilder::new().encode_array(|builder| {
+            builder.encode_u64(10).encode_u64(100);
+        });
+        let cbor = cbor.decode();
+        assert!(validate_dict(&cbor).is_err());
+    }
+
+    #[test]
+    fn test_validate_record() {
+        // { "temperature": 100, { "coordinates": { "x": 10, "y": -10 } } }
+        let cbor = CborBuilder::new().encode_dict(|builder| {
+            // TODO: number support
+            builder.with_key("temperature", |builder| builder.encode_i64(100));
+            builder.with_key("coordinates", |builder| {
+                builder.encode_dict(|builder| {
+                    builder.with_key("x", |builder| builder.encode_i64(10));
+                    builder.with_key("y", |builder| builder.encode_i64(10));
+                })
+            });
+        });
+        let cbor = cbor.decode();
+        let ty = vec![
+            (
+                Label::String("temperature".to_string().try_into().expect("non-empty string")),
+                Type::Atom(TypeAtom::Number(None)),
+            ),
+            (
+                Label::String("coordinates".to_string().try_into().expect("non-empty string")),
+                Type::Record(
+                    vec![
+                        (
+                            Label::String("x".to_string().try_into().expect("non-empty string")),
+                            Type::Atom(TypeAtom::Number(None)),
+                        ),
+                        (
+                            Label::String("y".to_string().try_into().expect("non-empty string")),
+                            Type::Atom(TypeAtom::Number(None)),
+                        ),
+                    ]
+                    .try_into()
+                    .expect("proper type"),
+                ),
+            ),
+        ]
+        .try_into()
+        .expect("proper type");
+        validate_record(&cbor, &ty).unwrap();
+        // assert!(validate_record(&cbor, &ty).is_ok());
+    }
+
+    #[test]
+    fn test_validate_union_simple() {
+        let cbor = CborBuilder::new().encode_null();
+        let cbor = cbor.decode();
+        let left = Type::Atom(TypeAtom::Null);
+        let right = Type::Atom(TypeAtom::Timestamp);
+        assert!(validate_union(&cbor, &(left.clone(), right.clone())).is_ok());
+        assert!(validate_union(&cbor, &(right.clone(), left.clone())).is_ok());
+    }
+
+    #[test]
+    fn test_validate_union_nested_bi() {
+        let left = {
+            let left = Type::Atom(TypeAtom::Null);
+            let right = Type::Atom(TypeAtom::Timestamp);
+            Arc::new((left, right))
+        };
+
+        let right = {
+            let left = Type::Atom(TypeAtom::Bool(Some(false)));
+            let right = Type::Atom(TypeAtom::String(Some("Olá!".to_string())));
+            Arc::new((left, right))
+        };
+
+        let cbor = CborBuilder::new().encode_str("Olá!");
+        let cbor = cbor.decode();
+
+        // Null | Timestamp
+        assert!(validate_union(&cbor, left.as_ref()).is_err());
+        // Bool(false) | String("Olá")
+        assert!(validate_union(&cbor, right.as_ref()).is_ok());
+        // (Null | Timestamp) | (Bool(false) | String("Olá"))
+        assert!(validate_union(&cbor, &((Type::Union(left), Type::Union(right)))).is_ok());
+    }
+
+    #[test]
+    fn test_validate_union_nested_leaning() {
+        // A | (B | (C | D)
+
+        let cbor = CborBuilder::new().encode_null();
+        let cbor = cbor.decode();
+
+        // Null | Timestamp
+        let first_union = {
+            let left = Type::Atom(TypeAtom::Null);
+            let right = Type::Atom(TypeAtom::Timestamp);
+            Arc::new((left, right))
+        };
+        assert!(validate_union(&cbor, first_union.as_ref()).is_ok());
+
+        // Boolean(false) | (Null | Timestamp)
+        let second_union = {
+            let left = Type::Atom(TypeAtom::Bool(Some(false)));
+            let right = Type::Union(first_union);
+            Arc::new((left, right))
+        };
+        assert!(validate_union(&cbor, second_union.as_ref()).is_ok());
+
+        // String("Olá") | (Boolean(false) | (Null | Timestamp))
+        let third_union = {
+            let left = Type::Atom(TypeAtom::String(Some("Olá".to_string())));
+            let right = Type::Union(second_union);
+            Arc::new((left, right))
+        };
+        assert!(validate_union(&cbor, third_union.as_ref()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_union_nested_leaning_fail() {
+        // A | (B | (C | D)
+
+        let cbor = CborBuilder::new().encode_null();
+        let cbor = cbor.decode();
+
+        // Null | Timestamp
+        let first_union = {
+            let left = Type::Atom(TypeAtom::Number(Some(10)));
+            let right = Type::Atom(TypeAtom::Timestamp);
+            Arc::new((left, right))
+        };
+        assert!(validate_union(&cbor, first_union.as_ref()).is_err());
+
+        // Boolean(false) | (Null | Timestamp)
+        let second_union = {
+            let left = Type::Atom(TypeAtom::Bool(Some(false)));
+            let right = Type::Union(first_union);
+            Arc::new((left, right))
+        };
+        assert!(validate_union(&cbor, second_union.as_ref()).is_err());
+
+        // String("Olá") | (Boolean(false) | (Null | Timestamp))
+        let third_union = {
+            let left = Type::Atom(TypeAtom::String(Some("Olá".to_string())));
+            let right = Type::Union(second_union);
+            Arc::new((left, right))
+        };
+        assert!(validate_union(&cbor, third_union.as_ref()).is_err());
+    }
+
+    #[test]
+    fn test_validate_intersection() {
+        let cbor = CborBuilder::new().encode_i64(10);
+        let cbor = cbor.decode();
+        let left = Type::Atom(TypeAtom::Number(None));
+        let right = Type::Atom(TypeAtom::Number(Some(10)));
+
+        assert!(validate_intersection(&cbor, &(left, right)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_intersection_fail() {
+        let cbor = CborBuilder::new().encode_i64(10);
+        let cbor = cbor.decode();
+        let left = Type::Atom(TypeAtom::Null);
+        let right = Type::Atom(TypeAtom::Timestamp);
+        assert!(validate_intersection(&cbor, &(left, right)).is_err_and(|err| {
+            let err_message = format!("failed to intersect {:?} and {:?}", TypeAtom::Null, TypeAtom::Timestamp);
+            err.to_string() == err_message
+        }));
+    }
+}

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -98,7 +98,7 @@ fn validate_string(value: &CborValue, string_refinement: &Option<String>) -> any
 fn validate_array(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
     // NOTE(duarte): this validate is incomplete because we're not supporting subtyping, hence, we're just checking for arrays
     if let Some(values) = value.as_array() {
-        for (i, value) in values.into_iter().enumerate() {
+        for (i, value) in values.iter().enumerate() {
             if let Err(err) = validate(&value.decode(), ty) {
                 return Err(anyhow::anyhow!("type mismatch, element {} is not of type {:?}", i, ty)).context(err);
             }
@@ -140,7 +140,7 @@ fn validate_dict(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
                 ))
                 .context(err);
             }
-            if let Err(err) = validate(&v.decode(), &ty) {
+            if let Err(err) = validate(&v.decode(), ty) {
                 return Err(anyhow::anyhow!(
                     "type mismatch, dict value for key {:?} is not {:?}",
                     decoded_key,
@@ -178,9 +178,7 @@ fn validate_record(value: &CborValue, ty: &NonEmptyVec<(Label, Type)>) -> anyhow
                     let cbor = CborBuilder::new().encode_str(string);
                     let cbor = Cow::Owned(cbor);
                     if let Some(value) = value.get(&cbor) {
-                        if let e @ Err(_) = validate(&value.decode(), ty) {
-                            return e;
-                        }
+                        validate(&value.decode(), ty)?;
                     } else {
                         return Err(anyhow::anyhow!("label {} does not exist in record", string));
                     }
@@ -191,9 +189,7 @@ fn validate_record(value: &CborValue, ty: &NonEmptyVec<(Label, Type)>) -> anyhow
                     let cbor = CborBuilder::new().encode_number(&number);
                     let cbor = Cow::Owned(cbor);
                     if let Some(value) = value.get(&cbor) {
-                        if let e @ Err(_) = validate(&value.decode(), ty) {
-                            return e;
-                        }
+                        validate(&value.decode(), ty)?;
                     } else {
                         return Err(anyhow::anyhow!("label {:?} does not exist in record", number));
                     }

--- a/rust/actyx/ax-core/src/runtime/query.rs
+++ b/rust/actyx/ax-core/src/runtime/query.rs
@@ -42,7 +42,7 @@ impl Query {
             }
         }
 
-        let (q, features, pragmas) = q.decompose();
+        let (q, features, pragmas, _workflows) = q.decompose();
         let q = q.rewrite(&mut Q(app_id)).0;
         let stages = q.ops.into_iter().map(Operation::from).collect();
         (

--- a/rust/actyx/swarm/cli/src/lib.rs
+++ b/rust/actyx/swarm/cli/src/lib.rs
@@ -194,7 +194,7 @@ impl std::str::FromStr for Command {
                 let addr: Multiaddr = parts.next().unwrap().parse()?;
                 Self::AddAddress(peer, addr)
             }
-            Some(">query") => Self::SubscribeQuery(Query::parse(s.split_at(7).1)?.forget_pragmas()),
+            Some(">query") => Self::SubscribeQuery(Query::parse(s.split_at(7).1)?.forget_pragmas_and_workflows()),
             Some(">append") => {
                 let events = serde_json::from_str(s.split_at(8).1).unwrap();
                 Self::Append(events)

--- a/rust/actyx/swarm/harness/src/bin/quickcheck_interleaved.rs
+++ b/rust/actyx/swarm/harness/src/bin/quickcheck_interleaved.rs
@@ -49,6 +49,8 @@ fn main() {
             features: vec![],
             source: Source::Events { from, order: None },
             ops: vec![],
+            events: Default::default(),
+            workflows: Default::default(),
         }
     }
     fn cnt_per_tag(cmds: &[TestCommand]) -> BTreeMap<TagSet, usize> {

--- a/rust/sdk/src/files.rs
+++ b/rust/sdk/src/files.rs
@@ -29,7 +29,7 @@ use ax_aql::{Query, StaticQuery};
 ///     now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 /// );
 /// let request = PrefetchRequest {
-///     query: Query::parse(&*query).unwrap().forget_pragmas(),
+///     query: Query::parse(&*query).unwrap().forget_pragmas_and_workflows(),
 ///     duration: Duration::from_secs(60 * 60 * 12),
 /// };
 /// ```


### PR DESCRIPTION
This is only the first step, pure syntax. The MACHINE operation yields a TODO variable binding
instead of doing anything useful. Before this becomes usable we must add some form of name checking
at least, ensuring that referenced workflows and event types actually exist. Ideally, we should also
add type-checking of the binder expressions in workflows, because we know the respective event types
now.

- fix snapshot invalidation
- add EVENT type parsing
- add workflow parsing
