### PR TITLE
Add concurrency support for CI

### DIFF
--- a/.github/workflows/artifacts-and-rc.yml
+++ b/.github/workflows/artifacts-and-rc.yml
@@ -166,8 +166,6 @@ jobs:
         with:
           registry: ghcr.io
           username: jmg-duarte
-          # At the time of writing (18/12) this token has a 30 day expiration date
-          # this is on purpose, so we replace this with a proper token for genie
           password: ${{ secrets.GHCR_REGISTRY_TOKEN }}
       - name: Make All MacOS
         run: make all-macos assert-clean

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - "master"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel for pull requests
+  cancel-in-progress: ${{ github.event_name == 'pull_request'}}
+
 env:
   RUST_BACKTRACE: 1
 
@@ -50,20 +55,33 @@ jobs:
           make validate-os-android assert-clean
       - run: make clean
 
-  validate:
+  validate-os:
+    runs-on: [self-hosted, Linux]
+    needs: check
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: make validate-os assert-clean
+      - run: make clean
+
+  validate-netsim:
     runs-on: [self-hosted, Linux]
     needs: check
     timeout-minutes: 60
 
-    strategy:
-      matrix:
-        product: [os, netsim]
-      fail-fast: false
+    concurrency:
+      # Avoid multiple netsim tests running at the same time
+      # as they nearly block the system and their error rate
+      # is higher when run at the same time
+      # In conjunction with the top `concurrency` this should
+      # stop PRs from running at the same time as a build
+      # for `master`, `release`, etc
+      group: validate-netsim
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v3
-      - name: Validate ${{matrix.product}}
-        run: make validate-${{matrix.product}} assert-clean
+      - run: make validate-netsim assert-clean
       - run: make clean
 
   validate-docs:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -119,7 +119,8 @@ jobs:
 
     needs:
       - check-android
-      - validate
+      - validate-os
+      - validate-netsim
       - validate-docs
 
     steps:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,9 +9,10 @@ on:
       - "master"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Only cancel for pull requests
-  cancel-in-progress: ${{ github.event_name == 'pull_request'}}
+  # If there's a PR number, it will result in cancelling the previous build for that PR
+  # this is needed because the PR event triggers on "meta" PR things, like comments but not pushes
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
This should help reduce netsim errors and CI load when pushing multiple consecutive updates to the same PR