### PR TITLE
Handle leftover issues from #683

### DIFF
--- a/rust/actyx/Cargo.lock
+++ b/rust/actyx/Cargo.lock
@@ -1119,9 +1119,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbor-data"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1165c64320670370b3d45dbf666b6f815223785f4b2def266fd25ba23458cd"
+checksum = "07680cd3da61de53e862172d28019a24e0bca45cb06ee47285a242219c7266ca"
 dependencies = [
  "base64 0.13.1",
  "cbor-data-derive",

--- a/rust/actyx/Cargo.lock
+++ b/rust/actyx/Cargo.lock
@@ -1119,9 +1119,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbor-data"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07680cd3da61de53e862172d28019a24e0bca45cb06ee47285a242219c7266ca"
+checksum = "657d4c9648d7e75b6e73d41ccf195001ffaafd0e85d33c19800a16b769682de4"
 dependencies = [
  "base64 0.13.1",
  "cbor-data-derive",
@@ -2889,7 +2889,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -7794,7 +7794,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core 0.51.1",
+ "windows-core",
  "windows-targets 0.48.5",
 ]
 
@@ -7805,15 +7805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/rust/actyx/ax-aql/src/language/mod.rs
+++ b/rust/actyx/ax-aql/src/language/mod.rs
@@ -978,7 +978,7 @@ mod for_tests {
 
     fn ident_chars() -> &'static [char] {
         static CHOICES: OnceCell<Vec<char>> = OnceCell::new();
-        &CHOICES.get_or_init(|| ('a'..='z').chain('A'..='Z').chain('0'..='9').collect())
+        CHOICES.get_or_init(|| ('a'..='z').chain('A'..='Z').chain('0'..='9').collect())
     }
     const MINUSCULE: Range<usize> = 0..26;
     const MAJUSCULE: Range<usize> = 26..52;
@@ -988,7 +988,7 @@ mod for_tests {
             fn minuscule(g: &mut Gen) -> NonEmptyString {
                 let mut s = NonEmptyString::new(*g.choose(&ident_chars()[MINUSCULE]).unwrap());
                 for _ in 0..g.size() {
-                    s.push(*g.choose(&ident_chars()[..]).unwrap());
+                    s.push(*g.choose(ident_chars()).unwrap());
                 }
                 s
             }
@@ -996,7 +996,7 @@ mod for_tests {
                 let mut s = NonEmptyString::new(*g.choose(&ident_chars()[MAJUSCULE]).unwrap());
                 s.push(*g.choose(&ident_chars()[MINUSCULE]).unwrap());
                 for _ in 0..g.size() {
-                    s.push(*g.choose(&ident_chars()[..]).unwrap());
+                    s.push(*g.choose(ident_chars()).unwrap());
                 }
                 s
             }

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -357,7 +357,7 @@ mod test {
     use ax_aql::{Label, Type, TypeAtom};
     use cbor_data::{
         value::{Precision, Timestamp},
-        Cbor, CborBuilder, Encoder, Writer,
+        Cbor, CborBuilder, CborOwned, Encoder, Writer,
     };
 
     #[test]
@@ -881,6 +881,28 @@ mod test {
                 b.write_item(Cbor::checked(&[0xd8u8, 24, 0x5f, 0x41, 0x18, 0x41, 0x2a, 0xff]).unwrap())
             });
         });
+        validate_record(
+            &dict.decode(),
+            &vec![(
+                Label::String("key".to_string().try_into().expect("non-empty string")),
+                Type::Atom(TypeAtom::Number(None)),
+            )]
+            .try_into()
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_non_panic() {
+        let dict = CborBuilder::new().encode_dict(|b| {
+            b.with_key("key", |b| {
+                b.write_item(Cbor::checked(&[0xd8u8, 24, 0x5f, 0x41, 0x18, 0x41, 0x2a, 0xff]).unwrap())
+            });
+        });
+
+        let dict = CborOwned::canonical(dict.as_slice()).unwrap();
+
         validate_record(
             &dict.decode(),
             &vec![(

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -286,10 +286,7 @@ fn validate_atom<'err>(value: &CborValue<'err>, ty: &'err TypeAtom) -> Result<()
     }
 }
 
-fn validate_record<'err>(
-    value: &CborValue<'err>,
-    ty: &'err NonEmptyVec<(Label, Type)>,
-) -> Result<(), TypeError<'err>> {
+fn validate_record<'err>(value: &CborValue<'err>, ty: &'err NonEmptyVec<(Label, Type)>) -> Result<(), TypeError<'err>> {
     if let Some(value) = value.as_dict() {
         for (label, ty) in ty.iter() {
             match label {

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -1,140 +1,200 @@
 use std::{borrow::Cow, sync::Arc};
 
-use anyhow::Context;
 use ax_aql::{Label, NonEmptyVec, Type, TypeAtom};
 use cbor_data::{value::Number, CborBuilder, CborValue, Encoder};
 
 // NOTE: check tarpaulin for test coverage, its always hard to ensure every path was checked and
 // in this case, it would be really useful: https://github.com/xd009642/tarpaulin
 
+#[derive(Debug, thiserror::Error)]
+pub enum TypeMismatchError {
+    #[error("expected value to have type NULL")]
+    Null,
+
+    #[error("expected value to have type BOOLEAN")]
+    Boolean,
+
+    #[error("expected value to be {expected} but received {received} instead")]
+    BooleanRefinement { expected: bool, received: bool },
+
+    #[error("expected value to have type NUMBER")]
+    Number,
+
+    #[error("expected value to be {expected} but received {received} instead")]
+    NumberRefinement { expected: u64, received: u64 },
+
+    #[error("expected value to be a 64-bit integer but received a 128-bit integer")]
+    NumberSize,
+
+    #[error("expected value to have type TIMESTAMP")]
+    Timestamp,
+
+    #[error("expected value to have type STRING")]
+    String,
+
+    #[error("expected value to be {expected}, received {received} instead")]
+    StringRefinement { expected: String, received: String },
+
+    #[error("expected value to have type ARRAY")]
+    Array,
+
+    #[error("expected element {index} of ARRAY to have type {ty:?}")]
+    ArrayElement { index: usize, ty: Type },
+
+    #[error("expected value to have type TUPLE")]
+    Tuple,
+
+    #[error("expected tuple value to have length {expected} but received {received} instead")]
+    TupleLength { expected: usize, received: usize },
+
+    #[error("expected element {index} of TUPLE to have type {ty:?}")]
+    TupleElement { index: usize, ty: Type },
+
+    #[error("expected value to have type DICT")]
+    Dict,
+
+    #[error("expected DICT keys to have type STRING or NUMBER")]
+    DictKeys,
+
+    #[error("expected value for key {key} to have type {ty:?}")]
+    DictValue {
+        // NOTE: the original key is a CborValue that is either a string or a number
+        // I selected to represent this key as a String to simplify the error printing process
+        key: String,
+        ty: Type,
+    },
+
+    #[error("expected value to have type RECORD")]
+    Record,
+
+    #[error("expected label {expected} to exist in RECORD")]
+    RecordLabelMissing { expected: String },
+}
+
 /// Check if a CBOR value is null.
-fn validate_null(value: &CborValue) -> anyhow::Result<()> {
+fn validate_null(value: &CborValue) -> Result<(), TypeMismatchError> {
     if value.is_null() {
         Ok(())
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be null"))
+        Err(TypeMismatchError::Null)
     }
 }
 
 /// Check if a CBOR value is a boolean or a boolean refinement (i.e. `true` or `false`).
-fn validate_bool(value: &CborValue, bool_refinement: &Option<bool>) -> anyhow::Result<()> {
+fn validate_bool(value: &CborValue, bool_refinement: &Option<bool>) -> Result<(), TypeMismatchError> {
     if let Some(value) = value.as_bool() {
-        if let Some(bool_refinement) = bool_refinement {
-            if value == *bool_refinement {
+        if let Some(bool_refinement) = *bool_refinement {
+            if value == bool_refinement {
                 Ok(())
             } else {
-                Err(anyhow::anyhow!(
-                    "type mismatch, expected value to be {}, received {} instead",
-                    bool_refinement,
-                    value
-                ))
+                Err(TypeMismatchError::BooleanRefinement {
+                    expected: bool_refinement,
+                    received: value,
+                })
             }
         } else {
             Ok(())
         }
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be a boolean"))
+        Err(TypeMismatchError::Boolean)
     }
 }
 
 /// Check if a CBOR value is an integer or an integer refinement (e.g. `10`).
-fn validate_number(value: &CborValue, number_refinement: &Option<u64>) -> anyhow::Result<()> {
+fn validate_number(value: &CborValue, number_refinement: &Option<u64>) -> Result<(), TypeMismatchError> {
     if let Some(Number::Int(value)) = value.as_number() {
         if let Ok(value) = u64::try_from(*value) {
             if let Some(number_refinement) = number_refinement {
                 if value == *number_refinement {
                     Ok(())
                 } else {
-                    Err(anyhow::anyhow!(
-                        "type mismatch, expected value to be {}, received {} instead",
-                        number_refinement,
-                        value
-                    ))
+                    Err(TypeMismatchError::NumberRefinement {
+                        expected: *number_refinement,
+                        received: value,
+                    })
                 }
             } else {
                 Ok(())
             }
         } else {
-            Err(anyhow::anyhow!(
-                "type mismatch, expected value to be a 64-bit integer but received a 128-bit integer instead"
-            ))
+            Err(TypeMismatchError::NumberSize)
         }
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be an integer"))
+        Err(TypeMismatchError::Number)
     }
 }
 
 /// Check if a CBOR value is a timestamp.
-fn validate_timestamp(value: &CborValue) -> anyhow::Result<()> {
+fn validate_timestamp(value: &CborValue) -> Result<(), TypeMismatchError> {
     if value.as_timestamp().is_some() {
         Ok(())
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be a timestamp"))
+        Err(TypeMismatchError::Timestamp)
     }
 }
 
 /// Check if a CBOR value is a string or a string refinement (e.g. "Hello").
-fn validate_string(value: &CborValue, string_refinement: &Option<String>) -> anyhow::Result<()> {
+fn validate_string(value: &CborValue, string_refinement: &Option<String>) -> Result<(), TypeMismatchError> {
     if let Some(value) = value.as_str() {
         if let Some(refinement) = string_refinement {
             if value == refinement {
                 Ok(())
             } else {
-                Err(anyhow::anyhow!(
-                    "type mismatch, expected value to be {}, received {} instead",
-                    refinement,
-                    value
-                ))
+                Err(TypeMismatchError::StringRefinement {
+                    expected: refinement.clone(),
+                    received: value.to_string(),
+                })
             }
         } else {
             Ok(())
         }
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be a string"))
+        Err(TypeMismatchError::String)
     }
 }
 
 /// Check if a CBOR value is an array. Can also be used to check for tuples (following RFC 7049).
-fn validate_array(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
+fn validate_array(value: &CborValue, ty: &Type) -> Result<(), TypeMismatchError> {
     if let Some(values) = value.as_array() {
         for (i, value) in values.iter().enumerate() {
-            if let Err(err) = validate(&value.decode(), ty) {
-                return Err(anyhow::anyhow!("type mismatch, element {} is not of type {:?}", i, ty)).context(err);
+            if validate(&value.decode(), ty).is_err() {
+                // TODO: add support for source and backtrace using the err content
+                return Err(TypeMismatchError::ArrayElement {
+                    index: i,
+                    ty: ty.clone(),
+                });
             }
         }
         Ok(())
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be an array"))
+        Err(TypeMismatchError::Array)
     }
 }
 
-fn validate_tuple(value: &CborValue, ty: &[Type]) -> anyhow::Result<()> {
+fn validate_tuple(value: &CborValue, ty: &[Type]) -> Result<(), TypeMismatchError> {
     if let Some(array) = value.as_array() {
         if array.len() != ty.len() {
-            return Err(anyhow::anyhow!(
-                "type mismatch, expected tuple to have length {} got {} instead",
-                ty.len(),
-                array.len()
-            ));
+            return Err(TypeMismatchError::TupleLength {
+                expected: ty.len(),
+                received: array.len(),
+            });
         }
         for (i, (value, ty)) in array.iter().zip(ty.iter()).enumerate() {
-            if let Err(err) = validate(&value.decode(), ty) {
-                return Err(anyhow::anyhow!(
-                    "type mismatch, expected element {} of the tuple to be {:?}",
-                    i,
-                    ty
-                ))
-                .context(err);
+            if validate(&value.decode(), ty).is_err() {
+                return Err(TypeMismatchError::TupleElement {
+                    index: i,
+                    ty: ty.clone(),
+                });
             }
         }
         Ok(())
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be an array"))
+        Err(TypeMismatchError::Tuple)
     }
 }
 
 /// Check if a CBOR value is a dictionary.
-fn validate_dict(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
+fn validate_dict(value: &CborValue, ty: &Type) -> Result<(), TypeMismatchError> {
     let key_type = Type::Union(Arc::new((
         Type::Atom(TypeAtom::String(None)),
         Type::Atom(TypeAtom::Number(None)),
@@ -142,24 +202,25 @@ fn validate_dict(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
     if let Some(dict) = value.as_dict() {
         for (k, v) in dict {
             let decoded_key = k.decode();
-            if let Err(err) = validate(&decoded_key, &key_type) {
-                return Err(anyhow::anyhow!(
-                    "type mismatch, dict keys can only be numbers or strings"
-                ))
-                .context(err);
+            if let Err(_) = validate(&decoded_key, &key_type) {
+                return Err(TypeMismatchError::DictKeys);
             }
-            if let Err(err) = validate(&v.decode(), ty) {
-                return Err(anyhow::anyhow!(
-                    "type mismatch, dict value for key {:?} is not {:?}",
-                    decoded_key,
-                    ty
-                ))
-                .context(err);
+            if let Err(_) = validate(&v.decode(), ty) {
+                let key = {
+                    if let Some(key) = decoded_key.clone().to_str() {
+                        key.to_string()
+                    } else if let Some(Number::Int(key)) = decoded_key.to_number() {
+                        key.to_string()
+                    } else {
+                        unreachable!("this error should have been caught earlier")
+                    }
+                };
+                return Err(TypeMismatchError::DictValue { key, ty: ty.clone() });
             }
         }
         Ok(())
     } else {
-        Err(anyhow::anyhow!("type mismatch, expected value to be a dictionary"))
+        Err(TypeMismatchError::Dict)
     }
 }
 
@@ -167,7 +228,7 @@ fn validate_dict(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
 // the issue is that a Record can nest arbitrarily deep and may use non-atom types
 // ideally, I would like to _not_ use recursion since we already had the stack issue in other places;
 // so we either ignore records here and handle them somewhere else or we handle them here, some how
-fn validate_atom(value: &CborValue, ty: &TypeAtom) -> anyhow::Result<()> {
+fn validate_atom(value: &CborValue, ty: &TypeAtom) -> Result<(), TypeMismatchError> {
     match ty {
         TypeAtom::Null => validate_null(value),
         TypeAtom::Bool(refinement) => validate_bool(value, refinement),
@@ -178,7 +239,7 @@ fn validate_atom(value: &CborValue, ty: &TypeAtom) -> anyhow::Result<()> {
     }
 }
 
-fn validate_record(value: &CborValue, ty: &NonEmptyVec<(Label, Type)>) -> anyhow::Result<()> {
+fn validate_record(value: &CborValue, ty: &NonEmptyVec<(Label, Type)>) -> Result<(), TypeMismatchError> {
     if let Some(value) = value.as_dict() {
         for (label, ty) in ty.iter() {
             match label {
@@ -188,29 +249,32 @@ fn validate_record(value: &CborValue, ty: &NonEmptyVec<(Label, Type)>) -> anyhow
                     if let Some(value) = value.get(&cbor) {
                         validate(&value.decode(), ty)?;
                     } else {
-                        return Err(anyhow::anyhow!("label {} does not exist in record", string));
+                        return Err(TypeMismatchError::RecordLabelMissing {
+                            expected: string.to_string(),
+                        });
                     }
                 }
                 Label::Number(number) => {
-                    let number = i128::from(*number);
-                    let number = Number::Int(number);
-                    let cbor = CborBuilder::new().encode_number(&number);
+                    let cbor_number = Number::Int(i128::from(*number));
+                    let cbor = CborBuilder::new().encode_number(&cbor_number);
                     let cbor = Cow::Owned(cbor);
                     if let Some(value) = value.get(&cbor) {
                         validate(&value.decode(), ty)?;
                     } else {
-                        return Err(anyhow::anyhow!("label {:?} does not exist in record", number));
+                        return Err(TypeMismatchError::RecordLabelMissing {
+                            expected: number.to_string(),
+                        });
                     }
                 }
             }
         }
         Ok(())
     } else {
-        Err(anyhow::anyhow!("expected a record (dict)"))
+        Err(TypeMismatchError::Record)
     }
 }
 
-fn validate(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
+fn validate(value: &CborValue, ty: &Type) -> Result<(), TypeMismatchError> {
     match ty {
         Type::Atom(atom) => validate_atom(value, atom),
         Type::Array(inner_ty) => validate_array(value, inner_ty),
@@ -219,7 +283,7 @@ fn validate(value: &CborValue, ty: &Type) -> anyhow::Result<()> {
         Type::Record(record) => validate_record(value, record),
         // We can make this much more efficient by checking more things beforehand
         // like intersecting types before decoding anything
-        Type::Union(union) => validate(value, &union.0).or_else(|err| validate(value, &union.1).context(err)),
+        Type::Union(union) => validate(value, &union.0).or_else(|_| validate(value, &union.1)),
         Type::Intersection(intersection) => {
             validate(value, &intersection.0).and_then(|_| validate(value, &intersection.1))
         }

--- a/rust/actyx/ax-core/src/runtime/operation/validation.rs
+++ b/rust/actyx/ax-core/src/runtime/operation/validation.rs
@@ -124,7 +124,7 @@ impl<'err, T> TypeErrorContext for Result<T, TypeError<'err>> {
 }
 
 /// Check if a CBOR value is null.
-fn validate_null<'a, 'err>(value: &CborValue) -> Result<(), TypeMismatchError<'err>> {
+fn validate_null<'err>(value: &CborValue) -> Result<(), TypeMismatchError<'err>> {
     if value.is_null() {
         Ok(())
     } else {
@@ -133,7 +133,7 @@ fn validate_null<'a, 'err>(value: &CborValue) -> Result<(), TypeMismatchError<'e
 }
 
 /// Check if a CBOR value is a boolean or a boolean refinement (i.e. `true` or `false`).
-fn validate_bool<'a, 'err>(value: &CborValue, bool_refinement: &Option<bool>) -> Result<(), TypeMismatchError<'err>> {
+fn validate_bool<'err>(value: &CborValue, bool_refinement: &Option<bool>) -> Result<(), TypeMismatchError<'err>> {
     if let Some(value) = value.as_bool() {
         if let Some(bool_refinement) = *bool_refinement {
             if value == bool_refinement {
@@ -153,10 +153,7 @@ fn validate_bool<'a, 'err>(value: &CborValue, bool_refinement: &Option<bool>) ->
 }
 
 /// Check if a CBOR value is an integer or an integer refinement (e.g. `10`).
-fn validate_number<'a, 'err>(
-    value: &CborValue,
-    number_refinement: &Option<u64>,
-) -> Result<(), TypeMismatchError<'err>> {
+fn validate_number<'err>(value: &CborValue, number_refinement: &Option<u64>) -> Result<(), TypeMismatchError<'err>> {
     if let Some(Number::Int(value)) = value.as_number() {
         if let Ok(value) = u64::try_from(*value) {
             if let Some(number_refinement) = number_refinement {
@@ -180,7 +177,7 @@ fn validate_number<'a, 'err>(
 }
 
 /// Check if a CBOR value is a timestamp.
-fn validate_timestamp<'a, 'err>(value: &CborValue) -> Result<(), TypeMismatchError<'err>> {
+fn validate_timestamp<'err>(value: &CborValue) -> Result<(), TypeMismatchError<'err>> {
     if value.as_timestamp().is_some() {
         Ok(())
     } else {
@@ -212,7 +209,7 @@ fn validate_string<'err>(
 }
 
 /// Check if a CBOR value is an array. Can also be used to check for tuples (following RFC 7049).
-fn validate_array<'a, 'err>(value: &CborValue<'err>, ty: &'err Type) -> Result<(), TypeMismatchError<'err>> {
+fn validate_array<'err>(value: &CborValue<'err>, ty: &'err Type) -> Result<(), TypeMismatchError<'err>> {
     if let Some(values) = value.as_array() {
         for (i, value) in values.iter().enumerate() {
             if validate(&value.decode(), ty).is_err() {


### PR DESCRIPTION
Handles:
> - if these errors are to be read by humans, they would be vastly more useful if they carried the context (i.e. the path inside the event payload object)
> - since these errors will usually not be read by humans and they are expensive to construct (string formatting), it would be really great if the error carried the information for printing but only did it in its Display impl

— _https://github.com/Actyx/Actyx/pull/683#discussion_r1528236382_